### PR TITLE
feat(#6): infraestrutura Firebase no backend (Admin SDK + emulador + ADR-006)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ compile_output.txt
 # OS
 .DS_Store
 Thumbs.db
+
+# Firebase service account (NUNCA commitar segredos)
+firebase-service-account*.json
+service-account*.json
+*.pem
+firebase-debug.log

--- a/docs/adr/006-firestore-incremental-migration.md
+++ b/docs/adr/006-firestore-incremental-migration.md
@@ -1,0 +1,101 @@
+# ADR-006: Persistência Dual Incremental — PostgreSQL + Firestore por Domínio
+
+## Status
+
+**Aceito** — 2026-09-04
+
+## Contexto
+
+O ADR-001 definiu Java + Firebase Firestore como arquitetura alvo. Na prática, o backend
+hoje é **100% PostgreSQL/JPA/Flyway** (construção estável). Migrar todas as entidades para
+Firestore de uma vez (big bang) já foi tentado nas issues #1–#5 e **revertido** (#5) por
+quebrar o build e a regra de negócio.
+
+É necessária uma estratégia incremental: manter o PostgreSQL como fonte de verdade padrão e
+adotar o Firestore **domínio a domínio**, com infraestrutura preparada, sem mudar regras de
+negócio, controllers, JPA ou Flyway.
+
+## Decisão
+
+1. **Persistência dual incremental**: PostgreSQL/JPA continua sendo o default. O Firestore é
+   habilitado por domínio através de flags `app.firestore.<domínio>=true` (default `false`).
+   Cada issue futura liga UM domínio, implementa `XxxFirestoreRepository` e valida com o
+   emulador antes de tocar em produção.
+2. **Escrita única via Java REST**: o **cliente web NÃO escreve direto no Firestore**. Toda
+   escrita passa pelo backend (Admin SDK). O Firestore é persistência/leitura (realtime) para
+   os apps (referee_app, public_app), nunca porta de escrita do cliente.
+3. **Padrão porta de repositório**: interface-base genérica
+   `br.com.flagplatform.common.firebase.FirestoreRepository<T>` (`findById`, `findAll`,
+   `save`, `delete`). Domínios migrados implementam:
+   `XxxFirestoreRepository implements XxxRepository, FirestoreRepository<XxxEntity>` com
+   `@ConditionalOnProperty(name = "app.firestore.<domínio>", havingValue = "true")`.
+   A interface `XxxRepository` (JPA) não muda; a troca de implementação é transparente para o service.
+4. **Emulador no perfil dev**: `FirestoreFactory` cria o bean `Firestore` apenas quando
+   `app.firestore.enabled=true` (`@ConditionalOnProperty`). Com host de emulador configurado,
+   usa `FirestoreOptions.setEmulatorHost(...)` + `EmulatorCredentials` (sem credencial real).
+   Sem host, usa a API real com service account (`FIREBASE_SERVICE_ACCOUNT` /
+   `GOOGLE_APPLICATION_CREDENTIALS` / ADC).
+5. **Regras de segurança Firestore**: leitura pública/autenticada por regras; escrita SOMENTE
+   via Admin SDK (Java). Regras a publicar junto com o primeiro domínio migrado.
+
+## Configuração (env vars)
+
+| Variável | Default | Uso |
+|----------|---------|-----|
+| `FIRESTORE_ENABLED` | `false` | Liga o Firestore no backend (`app.firestore.enabled`) |
+| `FIRESTORE_EMULATOR_HOST` | `localhost:9090` (perfil dev) | Host do emulador (`host:porta`, sem esquema) |
+| `FIREBASE_SERVICE_ACCOUNT` | — | Caminho do JSON do service account (prod) |
+| `GOOGLE_APPLICATION_CREDENTIALS` | — | Alternativa padrão Google (prod) |
+| `FIREBASE_PROJECT_ID` | `flag-platform` | Project ID (emulador/prod sem service account) |
+| `GCLOUD_PROJECT` | — | Fallback de project id |
+
+**Porta do emulador**: o default do Firebase Emulator Suite para Firestore é `8080`, mas o
+backend roda em `8080` — default em `dev` é **`localhost:9090`** para não conflitar, sempre
+sobrescrevível via `FIRESTORE_EMULATOR_HOST`. Subir o emulador:
+
+```bash
+firebase emulators:start --only firestore --project flag-platform   # porta 9090 via firebase.json
+# ou
+firebase emulators:start --only firestore --project flag-platform --port 9090
+```
+
+## Não escopo desta issue
+
+- Nenhum domínio foi migrado (flags por domínio permanecem `false`).
+- JPA, Flyway, PostgreSQL, controllers, services e regras de negócio inalterados.
+- Nenhum segredo no repositório: `firebase-service-account*.json` / `service-account*.json`
+  estão no `.gitignore`.
+
+## Estratégia de testes
+
+A Flag Platform **não adota testes unitários/integração dentro das aplicações** (premissa de
+produtividade — aceleração da codificação). A validação é feita por **testes e2e fora das
+aplicações** (camada de QA dedicada). A garantia técnica desta fase é o build verde:
+`./mvnw compile` (CI) e a validação manual com o emulador quando o domínio migrado estiver
+ativo (`firebase emulators:start --only firestore --project flag-platform`).
+
+## Consequências
+
+### Positivas
+
+1. Incremental e reversível: cada domínio migra e valida isoladamente.
+2. Zero impacto no que está estável (JPA/Postgres).
+3. Cliente web nunca escreve direto no Firestore — regras de segurança simples e auditáveis.
+4. Real-time/offline possíveis por domínio (referee_app/public_app) quando a flag ligar.
+
+### Negativas
+
+1. Duas persistências para manter durante a transição (escrita dupla por domínio migrado).
+2. Firestore por domínio pode criar divergência temporária de dados até a migração completa.
+3. Dependência nova (`firebase-admin`) e superfície de configuração por ambiente.
+
+## Referências
+
+- ADR-001: Arquitetura Backend - Java + Firebase (Firestore)
+- Issue #6 — feat: infraestrutura Firebase no backend (Admin SDK + emulador + ADR-006)
+- [Firestore emulator + Admin SDKs](https://firebase.google.com/docs/emulator-suite/connect_firestore)
+
+## Revisado por
+
+- Tech Lead: Flag Platform
+- Data: 2026-09-04

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <springdoc.version>3.0.3</springdoc.version>
         <spring-modulith.version>2.1.0</spring-modulith.version>
         <jjwt.version>0.12.6</jjwt.version>
+        <firebase-admin.version>9.10.0</firebase-admin.version>
     </properties>
 
     <dependencyManagement>
@@ -97,6 +98,13 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
+
+        <!-- Firebase Admin SDK (Firestore) -->
+        <dependency>
+            <groupId>com.google.firebase</groupId>
+            <artifactId>firebase-admin</artifactId>
+            <version>${firebase-admin.version}</version>
         </dependency>
 
         <!-- OpenAPI / Swagger (SpringDoc 3.x = Spring Boot 4.x) -->

--- a/src/main/java/br/com/flagplatform/common/firebase/FirestoreFactory.java
+++ b/src/main/java/br/com/flagplatform/common/firebase/FirestoreFactory.java
@@ -1,0 +1,205 @@
+package br.com.flagplatform.common.firebase;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.internal.EmulatorCredentials;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Fábrica do Firestore (Admin SDK) para persistência dual — PostgreSQL (default)
+ * + Firestore por domínio. Ver ADR-006.
+ *
+ * <p>O bean {@code Firestore} só é criado quando a flag {@code app.firestore.enabled}
+ * é {@code true} ({@link ConditionalOnProperty}). Enquanto nenhum domínio for migrado,
+ * a flag fica {@code false} e nenhuma inicialização do Firebase acontece.
+ *
+ * <h2>Configuração por ambiente</h2>
+ * <ul>
+ *   <li><b>Emulador local (perfil {@code dev})</b>: ativado quando o host do emulador é
+ *       resolvido. Resolução em ordem: propriedade {@code app.firestore.emulator-host}
+ *       (application-dev.yml → {@code ${FIRESTORE_EMULATOR_HOST:localhost:9090}}) e depois
+ *       a env var {@code FIRESTORE_EMULATOR_HOST}. Neste modo as credenciais são fictícias
+ *       ({@link EmulatorCredentials}) e o host é passado via
+ *       {@link FirestoreOptions.Builder#setEmulatorHost(String)}.</li>
+ *   <li><b>API real do Firebase (prod)</b>: sem host de emulador. Credenciais vindas de
+ *       {@code FIREBASE_SERVICE_ACCOUNT} (caminho do JSON), {@code GOOGLE_APPLICATION_CREDENTIALS}
+ *       ou Application Default Credentials.</li>
+ *   <li><b>Perfil {@code local}</b>: permanece somente PostgreSQL — a flag
+ *       {@code app.firestore.enabled} fica {@code false} (application-local.yml).</li>
+ * </ul>
+ *
+ * <p>O projeto id é resolvido de {@code app.firestore.project-id} (env
+ * {@code FIREBASE_PROJECT_ID}), do campo {@code project_id} do JSON do service account,
+ * da env {@code GCLOUD_PROJECT} ou, como último recurso, do default {@code flag-platform}.
+ *
+ * <p>Observação: {@code FirestoreOptions} é construído explicitamente (e não via
+ * {@code FirestoreOptions.getDefaultInstance()}) para não acoplar a instância ao
+ * {@code FirebaseApp} default nem a estado estático entre contextos.
+ */
+@Slf4j
+@Configuration
+public class FirestoreFactory {
+
+    public static final String PROP_ENABLED = "app.firestore.enabled";
+    public static final String PROP_EMULATOR_HOST = "app.firestore.emulator-host";
+    public static final String PROP_PROJECT_ID = "app.firestore.project-id";
+
+    public static final String ENV_FIRESTORE_EMULATOR_HOST = "FIRESTORE_EMULATOR_HOST";
+    public static final String ENV_FIREBASE_SERVICE_ACCOUNT = "FIREBASE_SERVICE_ACCOUNT";
+    public static final String ENV_GOOGLE_APPLICATION_CREDENTIALS = "GOOGLE_APPLICATION_CREDENTIALS";
+    public static final String ENV_GCLOUD_PROJECT = "GCLOUD_PROJECT";
+
+    private static final String DEFAULT_PROJECT_ID = "flag-platform";
+
+    /**
+     * Expõe o {@link Firestore} do Admin SDK. Bean condicionado à flag
+     * {@code app.firestore.enabled=true} — sem a flag, o Firebase não é tocado.
+     */
+    @Bean
+    @ConditionalOnProperty(name = PROP_ENABLED, havingValue = "true")
+    public Firestore firestore(Environment environment) throws IOException {
+        String emulatorHost = resolveEmulatorHost(environment);
+        GoogleCredentials credentials = resolveCredentials(emulatorHost);
+        String projectId = resolveProjectId(environment, credentials);
+
+        FirestoreOptions.Builder optionsBuilder = FirestoreOptions.newBuilder()
+                .setProjectId(projectId);
+
+        if (emulatorHost != null) {
+            // Credenciais do Firebase ficam fictícias; o FirestoreOptions cuida do
+            // endpoint (plaintext + EmulatorCredentials) internamente.
+            optionsBuilder.setEmulatorHost(emulatorHost);
+            log.info("Firestore conectado ao EMULADOR local em {}", emulatorHost);
+        } else {
+            optionsBuilder.setCredentials(credentials);
+            log.info("Firestore conectado ao Firebase Cloud (projectId={})", projectId);
+        }
+
+        FirestoreOptions firestoreOptions = optionsBuilder.build();
+
+        FirebaseOptions firebaseOptions = FirebaseOptions.builder()
+                .setCredentials(credentials)
+                .setProjectId(projectId)
+                .setFirestoreOptions(firestoreOptions)
+                .build();
+
+        FirebaseApp app = FirebaseApp.getApps().stream()
+                .filter(candidate -> candidate.getName().equals(FirebaseApp.DEFAULT_APP_NAME))
+                .findFirst()
+                .orElseGet(() -> FirebaseApp.initializeApp(firebaseOptions));
+
+        return firestoreOptions.getService();
+    }
+
+    /**
+     * Resolve o host do emulador: propriedade {@code app.firestore.emulator-host} primeiro,
+     * depois a env var {@code FIRESTORE_EMULATOR_HOST}. Retorna {@code null} quando nenhum
+     * host é configurado (modo API real).
+     */
+    String resolveEmulatorHost(Environment environment) {
+        String fromProperty = environment.getProperty(PROP_EMULATOR_HOST);
+        if (fromProperty != null && !fromProperty.isBlank()) {
+            return normalizeHost(fromProperty);
+        }
+        String fromEnv = System.getenv(ENV_FIRESTORE_EMULATOR_HOST);
+        if (fromEnv != null && !fromEnv.isBlank()) {
+            return normalizeHost(fromEnv);
+        }
+        return null;
+    }
+
+    private String normalizeHost(String host) {
+        String normalized = host.trim();
+        int scheme = normalized.indexOf("://");
+        return scheme >= 0 ? normalized.substring(scheme + 3) : normalized;
+    }
+
+    /**
+     * Em modo emulador usa {@link EmulatorCredentials} (o emulador ignora autenticação).
+     * Em produção: {@code FIREBASE_SERVICE_ACCOUNT} primeiro, depois
+     * {@code GOOGLE_APPLICATION_CREDENTIALS}, e por fim Application Default Credentials.
+     */
+    GoogleCredentials resolveCredentials(String emulatorHost) throws IOException {
+        if (emulatorHost != null) {
+            return new EmulatorCredentials();
+        }
+        String serviceAccountPath = firstNonBlank(
+                System.getenv(ENV_FIREBASE_SERVICE_ACCOUNT),
+                System.getenv(ENV_GOOGLE_APPLICATION_CREDENTIALS));
+        if (serviceAccountPath != null) {
+            Path path = Path.of(serviceAccountPath);
+            if (!Files.exists(path)) {
+                throw new IllegalStateException(
+                        "Service account do Firebase não encontrado em '" + path
+                                + "'. Configure FIREBASE_SERVICE_ACCOUNT ou GOOGLE_APPLICATION_CREDENTIALS.");
+            }
+            try (FileInputStream input = new FileInputStream(path.toFile())) {
+                return GoogleCredentials.fromStream(input);
+            }
+        }
+        return GoogleCredentials.getApplicationDefault();
+    }
+
+    /**
+     * Resolve o project id, em ordem: propriedade {@code app.firestore.project-id}
+     * ({@code FIREBASE_PROJECT_ID}), campo {@code project_id} do JSON do service account,
+     * env {@code GCLOUD_PROJECT} e default {@code flag-platform}.
+     */
+    String resolveProjectId(Environment environment, GoogleCredentials credentials) {
+        String configured = environment.getProperty(PROP_PROJECT_ID);
+        if (configured != null && !configured.isBlank()) {
+            return configured;
+        }
+        String projectFromCredentials = projectIdFromServiceAccountFile();
+        if (projectFromCredentials != null) {
+            return projectFromCredentials;
+        }
+        String envProject = System.getenv(ENV_GCLOUD_PROJECT);
+        if (envProject != null && !envProject.isBlank()) {
+            return envProject;
+        }
+        return DEFAULT_PROJECT_ID;
+    }
+
+    private String projectIdFromServiceAccountFile() {
+        String serviceAccountPath = firstNonBlank(
+                System.getenv(ENV_FIREBASE_SERVICE_ACCOUNT),
+                System.getenv(ENV_GOOGLE_APPLICATION_CREDENTIALS));
+        if (serviceAccountPath == null) {
+            return null;
+        }
+        try (Reader reader = Files.newBufferedReader(Path.of(serviceAccountPath))) {
+            JsonObject json = JsonParser.parseReader(reader).getAsJsonObject();
+            if (json.has("project_id") && !json.get("project_id").isJsonNull()) {
+                return json.get("project_id").getAsString();
+            }
+        } catch (IOException | RuntimeException e) {
+            log.warn("Não foi possível ler project_id do service account '{}': {}", serviceAccountPath, e.getMessage());
+        }
+        return null;
+    }
+
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/br/com/flagplatform/common/firebase/FirestoreRepository.java
+++ b/src/main/java/br/com/flagplatform/common/firebase/FirestoreRepository.java
@@ -1,0 +1,66 @@
+package br.com.flagplatform.common.firebase;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Interface-base (porta) para repositórios Firestore por domínio — ADR-006.
+ *
+ * <p>Habilita a <b>persistência dual</b>: PostgreSQL/JPA continua sendo a escrita padrão
+ * e o Firestore é adotado <b>domínio a domínio</b>, sem big bang. Cada domínio que migrar
+ * deve seguir o padrão de porta de repositório:
+ *
+ * <pre>{@code
+ * // 1. Interface do domínio (JPA, padrão atual) — NÃO muda:
+ * public interface OrganizationRepository extends JpaRepository<OrganizationEntity, UUID> { ... }
+ *
+ * // 2. Implementação Firestore do domínio (nas próximas issues), ativada por flag:
+ * @Component
+ * @ConditionalOnProperty(name = "app.firestore.organization", havingValue = "true")
+ * public class OrganizationFirestoreRepository
+ *         implements OrganizationRepository, FirestoreRepository<OrganizationEntity> { ... }
+ * }</pre>
+ *
+ * <p>A troca é por domínio: enquanto {@code app.firestore.<domínio>} estiver {@code false},
+ * a implementação JPA (Spring Data) continua sendo o único bean do repositório; ao ligar a
+ * flag, o bean Firestore entra com a mesma interface do domínio e passa a atender o service
+ * sem alteração nas regras de negócio.
+ *
+ * <h2>Mapeamento de ids</h2>
+ * <p>As entidades JPA usam {@link java.util.UUID} ({@code BaseEntity}); no Firestore o
+ * documento é identificado por {@link String}. A implementação Firestore deve usar
+ * {@code id.toString()} como document id e reconverter {@code UUID.fromString(...)} na leitura.
+ *
+ * <h2>Contratos</h2>
+ * <ul>
+ *   <li>Coleção de escrita: Java REST (Admin SDK) — o cliente web NUNCA escreve direto no Firestore.</li>
+ *   <li>Leitura: Firestore (realtime) + regras de segurança com leitura pública/autenticada.</li>
+ *   <li>Documentos armazenados em mapas próprios por domínio (dto/entity), nunca entidades JPA diretas.</li>
+ * </ul>
+ *
+ * @param <T> tipo do documento/entidade persistido pelo repositório Firestore
+ */
+public interface FirestoreRepository<T> {
+
+    /**
+     * Busca um documento por id ({@code UUID.toString()} do {@code BaseEntity}).
+     */
+    Optional<T> findById(String id);
+
+    /**
+     * Lista todos os documentos da coleção do domínio.
+     */
+    List<T> findAll();
+
+    /**
+     * Grava (cria ou atualiza) um documento na coleção do domínio.
+     *
+     * @return a entidade persistida (com id resolvido, se gerado pelo Firestore)
+     */
+    T save(T entity);
+
+    /**
+     * Remove o documento com o id informado. Não lança erro se o documento não existir.
+     */
+    void delete(String id);
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,6 +13,14 @@ spring:
   flyway:
     enabled: true
 
+app:
+  firestore:
+    # Perfil dev usa o EMULADOR local do Firestore (default ON).
+    # Porta 9090 por padrão para não conflitar com o backend (8080).
+    # Para usar outra porta, exporte FIRESTORE_EMULATOR_HOST antes de subir.
+    enabled: ${FIRESTORE_ENABLED:true}
+    emulator-host: ${FIRESTORE_EMULATOR_HOST:localhost:9090}
+
 logging:
   level:
     br.com.flagplatform: DEBUG

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,12 @@ spring:
   flyway:
     enabled: true
 
+app:
+  firestore:
+    # Perfil local permanece somente PostgreSQL — Firestore desligado (flag false).
+    # A factory só é ativada quando app.firestore.enabled=true.
+    enabled: ${FIRESTORE_ENABLED:false}
+
 logging:
   level:
     br.com.flagplatform: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,6 +72,23 @@ app:
     # por e-mail; quando false (dev), o token é retornado na resposta.
     enabled: ${MAIL_ENABLED:false}
 
+  firestore:
+    # Habilita o Firestore (Admin SDK) no backend — persistência dual com PostgreSQL.
+    # Default false: o backend continua 100% PostgreSQL/JPA. Liga por ambiente com
+    # FIRESTORE_ENABLED=true (o perfil dev já defaulta true + emulador).
+    enabled: ${FIRESTORE_ENABLED:false}
+    # Host do emulador local no formato host:porta (sem esquema). Vazio integra com a
+    # API real do Firebase (prod). Default do perfil dev: localhost:9090 (evita conflito
+    # com o backend em 8080) — ver application-dev.yml.
+    emulator-host: ${FIRESTORE_EMULATOR_HOST:}
+    # Project ID do Firebase. Usado pelo emulador e exigido quando não há service account.
+    project-id: ${FIREBASE_PROJECT_ID:flag-platform}
+    # ── Flags por domínio (default false) ─────────────────────────────────────
+    # Ligar domínio a domínio nas próximas issues; nesta issue nenhum domínio é
+    # migrado (apenas a infraestrutura raiz). Exemplos de estrutura futura:
+    #   athlete: ${FIRESTORE_ATHLETE_ENABLED:false}
+    #   organization: ${FIRESTORE_ORGANIZATION_ENABLED:false}
+
 springdoc:
   api-docs:
     path: /api-docs


### PR DESCRIPTION
**Issue:** #6 — feat: infraestrutura Firebase no backend (Admin SDK + emulador + ADR-006)
**História:** H1 (infra raiz) — prepara o backend para **persistência dual incremental** (PostgreSQL hoje + Firestore por domínio), sem big bang.

## Alterações
- **pom.xml**: dependência `com.google.firebase:firebase-admin` (9.10.0)
- **.gitignore**: `firebase-service-account*.json`, `service-account*.json`, `*.pem` (nunca commitar segredos)
- **Config**: flags `app.firestore.*` em `application.yml` (default OFF), `application-dev.yml` (emulador ON, `localhost:9090`) e `application-local.yml` (OFF — Postgres puro)
- **`common/firebase/FirestoreFactory`**: bean `Firestore` condicional (`app.firestore.enabled=true`); emulador via `FIRESTORE_EMULATOR_HOST`; credenciais por env (`FIREBASE_SERVICE_ACCOUNT` / `GOOGLE_APPLICATION_CREDENTIALS` / ADC)
- **`common/firebase/FirestoreRepository<T>`**: porta base para implementações Firestore por domínio (issues #7+)
- **docs/adr/006**: ADR-006 — persistência dual incremental, escrita única via Java REST, leitura Firestore, regras de segurança (leitura pública/escrita negada)

## Não escopo (mantido)
Nenhum domínio migrado; JPA/Flyway/PostgreSQL, controllers e regras de negócio **inalterados**.

## Testes
- `.\mvnw.cmd compile` → BUILD SUCCESS (EXIT 0)
- `.\mvnw.cmd test` → BUILD SUCCESS (EXIT 0)
- Premissa de testes: **sem testes unitários** nas aplicações — validação e2e fora das aplicações (registrado no ADR-006)

Closes #6