### PR TITLE
feat(#7): migrar domínio Organizações para Firestore (persistência dual)

### DIFF
--- a/src/main/java/br/com/flagplatform/organization/firestore/OrganizationFirestoreBackfill.java
+++ b/src/main/java/br/com/flagplatform/organization/firestore/OrganizationFirestoreBackfill.java
@@ -1,0 +1,76 @@
+package br.com.flagplatform.organization.firestore;
+
+import br.com.flagplatform.organization.entity.OrganizationEntity;
+import br.com.flagplatform.organization.repository.OrganizationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Backfill one-shot do domínio Organization (ADR-006): copia as organizações do
+ * PostgreSQL (fonte autoritativa) para o Firestore de forma <b>idempotente</b>.
+ * Ativado apenas quando {@code app.firestore.organization=true} (perfil dev).
+ *
+ * <p>Regra por organização (comparando o documento atual do Firestore com o esperado):
+ * <ul>
+ *   <li>documento inexistente → cria;</li>
+ *   <li>documento diferente → sobrescreve (atualiza);</li>
+ *   <li>documento idêntico → ignora (não duplica nem regrava).</li>
+ * </ul>
+ *
+ * <p>Pode rodar repetidas vezes sem efeito colateral; ao final registra a contagem
+ * {@code backfill organizations: X criadas, Y atualizadas, Z ignoradas}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.organization", havingValue = "true")
+public class OrganizationFirestoreBackfill implements ApplicationRunner {
+
+    private static final int PAGE_SIZE = 500;
+
+    private final OrganizationRepository jpaRepository;
+    private final OrganizationFirestoreRepository firestoreRepository;
+    private final OrganizationFirestoreMapper mapper;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Map<String, OrganizationFirestoreDocument> existing = firestoreRepository.findAll().stream()
+                .collect(Collectors.toMap(OrganizationFirestoreDocument::id, document -> document));
+
+        int created = 0;
+        int updated = 0;
+        int ignored = 0;
+
+        int page = 0;
+        Page<OrganizationEntity> result;
+        do {
+            result = jpaRepository.findAll(PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.ASC, "id")));
+            for (OrganizationEntity entity : result.getContent()) {
+                OrganizationFirestoreDocument expected = mapper.toDocument(entity);
+                OrganizationFirestoreDocument current = existing.get(entity.getId().toString());
+                if (current == null) {
+                    firestoreRepository.save(expected);
+                    created++;
+                } else if (expected.equals(current)) {
+                    ignored++;
+                } else {
+                    firestoreRepository.save(expected);
+                    updated++;
+                }
+            }
+            page++;
+        } while (result.hasNext());
+
+        log.info("backfill organizations: {} criadas, {} atualizadas, {} ignoradas", created, updated, ignored);
+    }
+}

--- a/src/main/java/br/com/flagplatform/organization/firestore/OrganizationFirestoreDocument.java
+++ b/src/main/java/br/com/flagplatform/organization/firestore/OrganizationFirestoreDocument.java
@@ -1,0 +1,172 @@
+package br.com.flagplatform.organization.firestore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Documento próprio do domínio Organization no Firestore (ADR-006) — espelho da
+ * entidade JPA {@code OrganizationEntity} em campos camelCase. NUNCA persistir a
+ * entidade JPA diretamente: o espelho usa este mapa próprio, estável para os apps
+ * (referee_app/public_app) que lerem a coleção {@code organizations} em realtime.
+ *
+ * <p>Tipos serializados (mapa simples, compatível com JSON):
+ * <ul>
+ *   <li>{@code id}/{@code parentId}/{@code createdBy}/{@code updatedBy}: UUID como {@code String};</li>
+ *   <li>{@code organizationType}/{@code documentType}/{@code status}: código do enum (mesmo valor
+ *       da coluna VARCHAR no PostgreSQL);</li>
+ *   <li>{@code createdAt}/{@code updatedAt}: {@code LocalDateTime} como ISO-8601
+ *       ({@code LocalDateTime.toString()});</li>
+ *   <li>demais campos: {@code String} ou ausentes quando {@code null}.</li>
+ * </ul>
+ *
+ * <p>Campos {@code null} são omitidos do documento ({@link #toMap()}) — o Firestore
+ * não armazena {@code null} e o {@code set(Map)} substitui o documento inteiro,
+ * removendo campos que deixaram de existir (ex.: {@code parentId} após desassociar).
+ *
+ * @param id              id UUID da organização ({@code UUID.toString()})
+ * @param legalName       razão social
+ * @param tradeName       nome fantasia
+ * @param abbreviation    sigla
+ * @param organizationType tipo da organização (código)
+ * @param document        CNPJ/CPF (somente dígitos)
+ * @param documentType    tipo do documento (código)
+ * @param presidentName   nome do presidente
+ * @param presidentCpf    CPF do presidente
+ * @param email           e-mail
+ * @param phone           telefone
+ * @param website         site
+ * @param instagram       instagram
+ * @param country         país (ISO 3166-1 alpha-2)
+ * @param state           estado
+ * @param city            cidade
+ * @param logoUrl         URL do logo
+ * @param primaryColor    cor primária (hex)
+ * @param secondaryColor  cor secundária (hex)
+ * @param tertiaryColor   cor terciária (hex)
+ * @param quaternaryColor cor quaternária (hex)
+ * @param timezone        fuso horário
+ * @param locale          locale
+ * @param status          status da organização (código)
+ * @param parentId        id da organização mãe ({@code UUID.toString()})
+ * @param createdAt       data de criação (ISO-8601)
+ * @param updatedAt       data da última atualização (ISO-8601)
+ * @param createdBy       id do usuário que criou ({@code UUID.toString()})
+ * @param updatedBy       id do usuário que atualizou ({@code UUID.toString()})
+ */
+public record OrganizationFirestoreDocument(
+        String id,
+        String legalName,
+        String tradeName,
+        String abbreviation,
+        String organizationType,
+        String document,
+        String documentType,
+        String presidentName,
+        String presidentCpf,
+        String email,
+        String phone,
+        String website,
+        String instagram,
+        String country,
+        String state,
+        String city,
+        String logoUrl,
+        String primaryColor,
+        String secondaryColor,
+        String tertiaryColor,
+        String quaternaryColor,
+        String timezone,
+        String locale,
+        String status,
+        String parentId,
+        String createdAt,
+        String updatedAt,
+        String createdBy,
+        String updatedBy
+) {
+
+    /**
+     * Converte o snapshot lido do Firestore (mapa) de volta para o documento.
+     * Campos ausentes viram {@code null}.
+     */
+    public static OrganizationFirestoreDocument fromMap(Map<String, Object> data) {
+        if (data == null || data.isEmpty()) {
+            return null;
+        }
+        return new OrganizationFirestoreDocument(
+                (String) data.get("id"),
+                (String) data.get("legalName"),
+                (String) data.get("tradeName"),
+                (String) data.get("abbreviation"),
+                (String) data.get("organizationType"),
+                (String) data.get("document"),
+                (String) data.get("documentType"),
+                (String) data.get("presidentName"),
+                (String) data.get("presidentCpf"),
+                (String) data.get("email"),
+                (String) data.get("phone"),
+                (String) data.get("website"),
+                (String) data.get("instagram"),
+                (String) data.get("country"),
+                (String) data.get("state"),
+                (String) data.get("city"),
+                (String) data.get("logoUrl"),
+                (String) data.get("primaryColor"),
+                (String) data.get("secondaryColor"),
+                (String) data.get("tertiaryColor"),
+                (String) data.get("quaternaryColor"),
+                (String) data.get("timezone"),
+                (String) data.get("locale"),
+                (String) data.get("status"),
+                (String) data.get("parentId"),
+                (String) data.get("createdAt"),
+                (String) data.get("updatedAt"),
+                (String) data.get("createdBy"),
+                (String) data.get("updatedBy"));
+    }
+
+    /**
+     * Converte o documento para o mapa gravado no Firestore, omitindo campos
+     * {@code null} (o Firestore não armazena null e o {@code set(Map)} sobrescreve
+     * o documento inteiro, removendo campos que deixaram de existir).
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> data = new HashMap<>();
+        putIfNotNull(data, "id", id);
+        putIfNotNull(data, "legalName", legalName);
+        putIfNotNull(data, "tradeName", tradeName);
+        putIfNotNull(data, "abbreviation", abbreviation);
+        putIfNotNull(data, "organizationType", organizationType);
+        putIfNotNull(data, "document", document);
+        putIfNotNull(data, "documentType", documentType);
+        putIfNotNull(data, "presidentName", presidentName);
+        putIfNotNull(data, "presidentCpf", presidentCpf);
+        putIfNotNull(data, "email", email);
+        putIfNotNull(data, "phone", phone);
+        putIfNotNull(data, "website", website);
+        putIfNotNull(data, "instagram", instagram);
+        putIfNotNull(data, "country", country);
+        putIfNotNull(data, "state", state);
+        putIfNotNull(data, "city", city);
+        putIfNotNull(data, "logoUrl", logoUrl);
+        putIfNotNull(data, "primaryColor", primaryColor);
+        putIfNotNull(data, "secondaryColor", secondaryColor);
+        putIfNotNull(data, "tertiaryColor", tertiaryColor);
+        putIfNotNull(data, "quaternaryColor", quaternaryColor);
+        putIfNotNull(data, "timezone", timezone);
+        putIfNotNull(data, "locale", locale);
+        putIfNotNull(data, "status", status);
+        putIfNotNull(data, "parentId", parentId);
+        putIfNotNull(data, "createdAt", createdAt);
+        putIfNotNull(data, "updatedAt", updatedAt);
+        putIfNotNull(data, "createdBy", createdBy);
+        putIfNotNull(data, "updatedBy", updatedBy);
+        return data;
+    }
+
+    private static void putIfNotNull(Map<String, Object> data, String key, String value) {
+        if (value != null) {
+            data.put(key, value);
+        }
+    }
+}

--- a/src/main/java/br/com/flagplatform/organization/firestore/OrganizationFirestoreMapper.java
+++ b/src/main/java/br/com/flagplatform/organization/firestore/OrganizationFirestoreMapper.java
@@ -1,0 +1,69 @@
+package br.com.flagplatform.organization.firestore;
+
+import br.com.flagplatform.common.enums.DocumentType;
+import br.com.flagplatform.common.enums.OrganizationStatus;
+import br.com.flagplatform.common.enums.OrganizationType;
+import br.com.flagplatform.organization.entity.OrganizationEntity;
+import org.mapstruct.Mapper;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Mapeia {@link OrganizationEntity} (JPA) ↔ {@link OrganizationFirestoreDocument}
+ * (espelho Firestore, ADR-006). Conversões próprias do domínio, em campos camelCase.
+ *
+ * <p>Enums são gravados pelo {@code code} (mesmo valor da coluna VARCHAR no Postgres,
+ * ex.: {@code CLUB}, {@code ACTIVE}, {@code CNPJ}); UUIDs e {@link LocalDateTime}
+ * viram {@code String} para manter o documento simples e JSON-friendly — ver
+ * {@link OrganizationFirestoreDocument}.
+ */
+@Mapper(componentModel = "spring")
+public interface OrganizationFirestoreMapper {
+
+    OrganizationFirestoreDocument toDocument(OrganizationEntity entity);
+
+    OrganizationEntity toEntity(OrganizationFirestoreDocument document);
+
+    // entity → documento
+    default String map(UUID value) {
+        return value == null ? null : value.toString();
+    }
+
+    default String map(OrganizationType value) {
+        return value == null ? null : value.getCode();
+    }
+
+    default String map(OrganizationStatus value) {
+        return value == null ? null : value.getCode();
+    }
+
+    default String map(DocumentType value) {
+        return value == null ? null : value.getCode();
+    }
+
+    default String map(LocalDateTime value) {
+        return value == null ? null : value.toString();
+    }
+
+    // documento → entity
+    default UUID mapUuid(String value) {
+        return value == null ? null : UUID.fromString(value);
+    }
+
+    default OrganizationType mapOrganizationType(String value) {
+        return value == null ? null : OrganizationType.valueOf(value);
+    }
+
+    default OrganizationStatus mapOrganizationStatus(String value) {
+        return value == null ? null : OrganizationStatus.valueOf(value);
+    }
+
+    default DocumentType mapDocumentType(String value) {
+        return value == null ? null : DocumentType.valueOf(value);
+    }
+
+    default LocalDateTime mapLocalDateTime(String value) {
+        return value == null ? null : LocalDateTime.parse(value);
+    }
+}

--- a/src/main/java/br/com/flagplatform/organization/firestore/OrganizationFirestoreRepository.java
+++ b/src/main/java/br/com/flagplatform/organization/firestore/OrganizationFirestoreRepository.java
@@ -1,0 +1,92 @@
+package br.com.flagplatform.organization.firestore;
+
+import br.com.flagplatform.common.firebase.FirestoreRepository;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.QuerySnapshot;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Implementação Firestore do domínio Organization (ADR-006) — piloto da persistência
+ * dual. Ativada apenas quando {@code app.firestore.organization=true} (e, por
+ * consequência, {@code app.firestore.enabled=true} para existir o bean {@link Firestore}
+ * do {@code FirestoreFactory}).
+ *
+ * <p>Este repositório é o <b>espelho de escrita</b> no Firestore: as leituras do
+ * fluxo REST continuam no PostgreSQL/JPA (fonte autoritativa) e a escrita é dupla
+ * (JPA + Firestore) — ver {@code DualOrganizationStore}. O tipo da porta é o
+ * {@link OrganizationFirestoreDocument} (mapa próprio do domínio), nunca a entidade JPA.
+ *
+ * <p>Publica todos os dados da organização na coleção {@code organizations}; id do
+ * documento = {@code UUID.toString()}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.organization", havingValue = "true")
+public class OrganizationFirestoreRepository implements FirestoreRepository<OrganizationFirestoreDocument> {
+
+    public static final String COLLECTION = "organizations";
+
+    private static final long OPERATION_TIMEOUT_SECONDS = 30;
+
+    private final Firestore firestore;
+
+    @Override
+    public Optional<OrganizationFirestoreDocument> findById(String id) {
+        DocumentSnapshot snapshot = await(firestore.collection(COLLECTION).document(id).get(), "ler");
+        if (!snapshot.exists()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(OrganizationFirestoreDocument.fromMap(snapshot.getData()));
+    }
+
+    @Override
+    public List<OrganizationFirestoreDocument> findAll() {
+        QuerySnapshot snapshots = await(firestore.collection(COLLECTION).get(), "listar");
+        return snapshots.getDocuments().stream()
+                .map(DocumentSnapshot::getData)
+                .map(OrganizationFirestoreDocument::fromMap)
+                .toList();
+    }
+
+    @Override
+    public OrganizationFirestoreDocument save(OrganizationFirestoreDocument document) {
+        Objects.requireNonNull(document, "document não pode ser nulo");
+        Objects.requireNonNull(document.id(), "id do documento não pode ser nulo");
+        DocumentReference reference = firestore.collection(COLLECTION).document(document.id());
+        await(reference.set(document.toMap()), "gravar");
+        log.debug("Organization espelhada no Firestore (id={})", document.id());
+        return document;
+    }
+
+    @Override
+    public void delete(String id) {
+        await(firestore.collection(COLLECTION).document(id).delete(), "remover");
+    }
+
+    private <T> T await(ApiFuture<T> future, String operation) {
+        try {
+            return future.get(OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    "Interrompido ao " + operation + " no Firestore (coleção organizations)", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new IllegalStateException(
+                    "Falha ao " + operation + " no Firestore (coleção organizations)", e);
+        }
+    }
+}

--- a/src/main/java/br/com/flagplatform/organization/repository/DualOrganizationStore.java
+++ b/src/main/java/br/com/flagplatform/organization/repository/DualOrganizationStore.java
@@ -1,0 +1,90 @@
+package br.com.flagplatform.organization.repository;
+
+import br.com.flagplatform.common.enums.OrganizationStatus;
+import br.com.flagplatform.common.enums.OrganizationType;
+import br.com.flagplatform.organization.entity.OrganizationEntity;
+import br.com.flagplatform.organization.firestore.OrganizationFirestoreMapper;
+import br.com.flagplatform.organization.firestore.OrganizationFirestoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementação <b>dual</b> da porta {@link OrganizationStore} (ADR-006), vigente
+ * quando {@code app.firestore.organization=true}: escrita dupla no PostgreSQL/JPA
+ * (autoritativa) e no Firestore (espelho para os apps), leitura sempre no JPA.
+ *
+ * <p>A escrita JPA usa {@code saveAndFlush} para materializar {@code id},
+ * {@code createdAt} e {@code updatedAt} (callbacks {@code @PrePersist}/{@code @PreUpdate})
+ * antes de espelhar no Firestore — o documento espelho reflete exatamente o que o
+ * Postgres registrou. Se o Firestore falhar, a exceção propaga e a transação JPA
+ * faz rollback (persistência dual fail-fast: ou grava nas duas, ou em nenhuma).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.organization", havingValue = "true")
+public class DualOrganizationStore implements OrganizationStore {
+
+    private final OrganizationRepository jpaRepository;
+    private final OrganizationFirestoreRepository firestoreRepository;
+    private final OrganizationFirestoreMapper mapper;
+
+    @Override
+    public OrganizationEntity save(OrganizationEntity entity) {
+        OrganizationEntity saved = jpaRepository.saveAndFlush(entity);
+        firestoreRepository.save(mapper.toDocument(saved));
+        log.debug("Organization persistida em dual store (id={})", saved.getId());
+        return saved;
+    }
+
+    @Override
+    public Optional<OrganizationEntity> findById(UUID id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public boolean existsByTradeNameIgnoreCase(String tradeName) {
+        return jpaRepository.existsByTradeNameIgnoreCase(tradeName);
+    }
+
+    @Override
+    public boolean existsByTradeNameIgnoreCaseAndIdNot(String tradeName, UUID id) {
+        return jpaRepository.existsByTradeNameIgnoreCaseAndIdNot(tradeName, id);
+    }
+
+    @Override
+    public boolean existsByDocument(String document) {
+        return jpaRepository.existsByDocument(document);
+    }
+
+    @Override
+    public boolean existsByDocumentAndIdNot(String document, UUID id) {
+        return jpaRepository.existsByDocumentAndIdNot(document, id);
+    }
+
+    @Override
+    public Page<OrganizationEntity> findAll(Pageable pageable) {
+        return jpaRepository.findAll(pageable);
+    }
+
+    @Override
+    public Page<OrganizationEntity> findAllByStatus(OrganizationStatus status, Pageable pageable) {
+        return jpaRepository.findAllByStatus(status, pageable);
+    }
+
+    @Override
+    public List<OrganizationEntity> findAllByParentIdAndOrganizationTypeInOrderByTradeNameAsc(
+            UUID parentId, Collection<OrganizationType> organizationTypes) {
+        return jpaRepository.findAllByParentIdAndOrganizationTypeInOrderByTradeNameAsc(parentId, organizationTypes);
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/organization/repository/JpaOrganizationStore.java
+++ b/src/main/java/br/com/flagplatform/organization/repository/JpaOrganizationStore.java
@@ -1,0 +1,76 @@
+package br.com.flagplatform.organization.repository;
+
+import br.com.flagplatform.common.enums.OrganizationStatus;
+import br.com.flagplatform.common.enums.OrganizationType;
+import br.com.flagplatform.organization.entity.OrganizationEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementação padrão (default) da porta {@link OrganizationStore}: delega
+ * integralmente ao repositório JPA/PostgreSQL atual. Vigora enquanto
+ * {@code app.firestore.organization} estiver {@code false} (ou ausente) — ou seja,
+ * comportamento 100% igual ao anterior à migração (ADR-006).
+ */
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.organization", havingValue = "false", matchIfMissing = true)
+public class JpaOrganizationStore implements OrganizationStore {
+
+    private final OrganizationRepository repository;
+
+    @Override
+    public OrganizationEntity save(OrganizationEntity entity) {
+        return repository.save(entity);
+    }
+
+    @Override
+    public Optional<OrganizationEntity> findById(UUID id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public boolean existsByTradeNameIgnoreCase(String tradeName) {
+        return repository.existsByTradeNameIgnoreCase(tradeName);
+    }
+
+    @Override
+    public boolean existsByTradeNameIgnoreCaseAndIdNot(String tradeName, UUID id) {
+        return repository.existsByTradeNameIgnoreCaseAndIdNot(tradeName, id);
+    }
+
+    @Override
+    public boolean existsByDocument(String document) {
+        return repository.existsByDocument(document);
+    }
+
+    @Override
+    public boolean existsByDocumentAndIdNot(String document, UUID id) {
+        return repository.existsByDocumentAndIdNot(document, id);
+    }
+
+    @Override
+    public Page<OrganizationEntity> findAll(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    @Override
+    public Page<OrganizationEntity> findAllByStatus(OrganizationStatus status, Pageable pageable) {
+        return repository.findAllByStatus(status, pageable);
+    }
+
+    @Override
+    public List<OrganizationEntity> findAllByParentIdAndOrganizationTypeInOrderByTradeNameAsc(
+            UUID parentId, Collection<OrganizationType> organizationTypes) {
+        return repository.findAllByParentIdAndOrganizationTypeInOrderByTradeNameAsc(parentId, organizationTypes);
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/organization/repository/OrganizationStore.java
+++ b/src/main/java/br/com/flagplatform/organization/repository/OrganizationStore.java
@@ -1,0 +1,47 @@
+package br.com.flagplatform.organization.repository;
+
+import br.com.flagplatform.common.enums.OrganizationStatus;
+import br.com.flagplatform.common.enums.OrganizationType;
+import br.com.flagplatform.organization.entity.OrganizationEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Porta de persistência do domínio Organization (ADR-006). Isola o
+ * {@code OrganizationService} da tecnologia de armazenamento e viabiliza a
+ * <b>persistência dual</b>: com {@code app.firestore.organization=false} vigora a
+ * implementação JPA/PostgreSQL ({@link JpaOrganizationStore}, padrão atual); com a
+ * flag {@code true} entra {@link DualOrganizationStore}, que mantém o PostgreSQL
+ * como escrita autoritativa e espelha toda escrita no Firestore.
+ *
+ * <p>As leituras sempre vêm do PostgreSQL (fonte de verdade); o Firestore é o
+ * espelho/realtime para os apps. Regras de negócio e contrato REST ficam intactos
+ * no service — ele conhece apenas esta porta.
+ */
+public interface OrganizationStore {
+
+    OrganizationEntity save(OrganizationEntity entity);
+
+    Optional<OrganizationEntity> findById(UUID id);
+
+    boolean existsByTradeNameIgnoreCase(String tradeName);
+
+    boolean existsByTradeNameIgnoreCaseAndIdNot(String tradeName, UUID id);
+
+    boolean existsByDocument(String document);
+
+    boolean existsByDocumentAndIdNot(String document, UUID id);
+
+    Page<OrganizationEntity> findAll(Pageable pageable);
+
+    Page<OrganizationEntity> findAllByStatus(OrganizationStatus status, Pageable pageable);
+
+    List<OrganizationEntity> findAllByParentIdAndOrganizationTypeInOrderByTradeNameAsc(
+            UUID parentId, Collection<OrganizationType> organizationTypes);
+
+}

--- a/src/main/java/br/com/flagplatform/organization/service/OrganizationService.java
+++ b/src/main/java/br/com/flagplatform/organization/service/OrganizationService.java
@@ -18,7 +18,7 @@ import br.com.flagplatform.organization.exception.OrganizationAssociationConflic
 import br.com.flagplatform.organization.exception.OrganizationAssociationNotFoundException;
 import br.com.flagplatform.organization.exception.OrganizationNotFoundException;
 import br.com.flagplatform.organization.mapper.OrganizationMapper;
-import br.com.flagplatform.organization.repository.OrganizationRepository;
+import br.com.flagplatform.organization.repository.OrganizationStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -50,7 +50,7 @@ public class OrganizationService implements OrganizationLookup {
             OrganizationType.UNIVERSITY);
 
     private final OrganizationMapper mapper;
-    private final OrganizationRepository repository;
+    private final OrganizationStore repository;
 
     @Transactional
     public OrganizationCreatedResponse create(CreateOrganizationRequest request) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,6 +20,9 @@ app:
     # Para usar outra porta, exporte FIRESTORE_EMULATOR_HOST antes de subir.
     enabled: ${FIRESTORE_ENABLED:true}
     emulator-host: ${FIRESTORE_EMULATOR_HOST:localhost:9090}
+    # Domínio piloto do ADR-006 (issue #7): organizações espelham no Firestore
+    # (persistência dual) quando a flag está true — default ON no perfil dev.
+    organization: ${FIRESTORE_ORGANIZATION_ENABLED:true}
 
 logging:
   level:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,6 +18,8 @@ app:
     # Perfil local permanece somente PostgreSQL — Firestore desligado (flag false).
     # A factory só é ativada quando app.firestore.enabled=true.
     enabled: ${FIRESTORE_ENABLED:false}
+    # Domínio organization também OFF no perfil local (padrão = sem espelho).
+    organization: ${FIRESTORE_ORGANIZATION_ENABLED:false}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,10 +84,10 @@ app:
     # Project ID do Firebase. Usado pelo emulador e exigido quando não há service account.
     project-id: ${FIREBASE_PROJECT_ID:flag-platform}
     # ── Flags por domínio (default false) ─────────────────────────────────────
-    # Ligar domínio a domínio nas próximas issues; nesta issue nenhum domínio é
-    # migrado (apenas a infraestrutura raiz). Exemplos de estrutura futura:
-    #   athlete: ${FIRESTORE_ATHLETE_ENABLED:false}
-    #   organization: ${FIRESTORE_ORGANIZATION_ENABLED:false}
+    # Cada domínio migra ligando a própria flag (ADR-006) — ligar somente quando
+    # app.firestore.enabled=true (bean Firestore ativo via FirestoreFactory).
+    # Issue #7 (piloto): organização espelha no Firestore quando true.
+    organization: ${FIRESTORE_ORGANIZATION_ENABLED:false}
 
 springdoc:
   api-docs:


### PR DESCRIPTION
**Issue:** #7 — feat: migrar domínio Organizações para Firestore (piloto ADR-006)
**História:** H3 — Domínio Organizações (piloto da persistência dual)

## Contexto
Persistência dual incremental (ADR-006): PostgreSQL/JPA continua sendo a **escrita autoritativa** e o **leitor** do REST; o Firestore é o **espelho** para os apps lerem em realtime. Esta issue é o **piloto do padrão** no domínio Organization.

## Alterações
- **`organization/firestore/OrganizationFirestoreDocument`** — documento próprio do domínio (29 campos camelCase), nunca a entidade JPA; `toMap()` omite `null` (Firestore não armazena null).
- **`OrganizationFirestoreMapper`** (MapStruct) — entity ↔ documento; enums por `code`, UUID/`LocalDateTime` como String.
- **`OrganizationFirestoreRepository`** — porta `FirestoreRepository<Document>`, coleção `organizations`, id = `UUID.toString()`, `@ConditionalOnProperty(app.firestore.organization=true)`, timeout 30s com fail-fast.
- **Porta `OrganizationStore`** + impls:
  - `JpaOrganizationStore` (default, flag OFF — comportamento atual inalterado);
  - `DualOrganizationStore` (flag ON) — JPA autoritativo + espelho Firestore com `saveAndFlush` (materializa `id`/`createdAt`/`updatedAt`); Firestore falhou → exceção propaga e **rollback JPA** (dual fail-fast). Leituras 100% JPA.
- **`OrganizationFirestoreBackfill`** (`ApplicationRunner`) — one-shot **idempotente** (página de 500): cria/atualiza/ignora por comparação de documento; log `backfill organizations: X criadas, Y atualizadas, Z ignoradas`.
- **Config**: `app.firestore.organization` — **dev ON** (`FIRESTORE_ORGANIZATION_ENABLED:true`), local/base OFF.

## Regras preservadas (inalteradas)
`OrganizationService` mudou **2 linhas** (injeta `OrganizationStore` no lugar do repository JPA): duplicidade de trade name/documento, hierarquia pai/filho, status ACTIVE/INACTIVE, associação de clubes e o contrato REST `/api/v1/organizations` **100% intactos**.

## Testes
- `.\mvnw.cmd clean compile` → **BUILD SUCCESS** (EXIT 0, validado de forma independente pelo tech-lead)
- Premissa: sem testes unitários nas aplicações (e2e fora das apps — ADR-006)
- Validação manual (dev): `firebase emulators:start --only firestore --project flag-platform` + perfil `dev` → backfill roda no boot e CRUD espelha na coleção `organizations`

Closes #7