### PR TITLE
feat(#8): migrar domínio Campos (Venue) para Firestore (persistência dual)

### DIFF
--- a/src/main/java/br/com/flagplatform/venue/firestore/VenueFirestoreBackfill.java
+++ b/src/main/java/br/com/flagplatform/venue/firestore/VenueFirestoreBackfill.java
@@ -1,0 +1,77 @@
+package br.com.flagplatform.venue.firestore;
+
+import br.com.flagplatform.venue.entity.VenueEntity;
+import br.com.flagplatform.venue.repository.VenueRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Backfill one-shot do domínio Venue (ADR-006): copia os venues do PostgreSQL
+ * (fonte autoritativa) para o Firestore de forma <b>idempotente</b> — seguindo o
+ * piloto Organization (issue #7). Ativado apenas quando {@code app.firestore.venue=true}
+ * (perfil dev).
+ *
+ * <p>Regra por venue (comparando o documento atual do Firestore com o esperado):
+ * <ul>
+ *   <li>documento inexistente → cria;</li>
+ *   <li>documento diferente → sobrescreve (atualiza);</li>
+ *   <li>documento idêntico → ignora (não duplica nem regrava).</li>
+ * </ul>
+ *
+ * <p>Pode rodar repetidas vezes sem efeito colateral; ao final registra a contagem
+ * {@code backfill venues: X criadas, Y atualizadas, Z ignoradas}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.venue", havingValue = "true")
+public class VenueFirestoreBackfill implements ApplicationRunner {
+
+    private static final int PAGE_SIZE = 500;
+
+    private final VenueRepository jpaRepository;
+    private final VenueFirestoreRepository firestoreRepository;
+    private final VenueFirestoreMapper mapper;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Map<String, VenueFirestoreDocument> existing = firestoreRepository.findAll().stream()
+                .collect(Collectors.toMap(VenueFirestoreDocument::id, document -> document));
+
+        int created = 0;
+        int updated = 0;
+        int ignored = 0;
+
+        int page = 0;
+        Page<VenueEntity> result;
+        do {
+            result = jpaRepository.findAll(PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.ASC, "id")));
+            for (VenueEntity entity : result.getContent()) {
+                VenueFirestoreDocument expected = mapper.toDocument(entity);
+                VenueFirestoreDocument current = existing.get(entity.getId().toString());
+                if (current == null) {
+                    firestoreRepository.save(expected);
+                    created++;
+                } else if (expected.equals(current)) {
+                    ignored++;
+                } else {
+                    firestoreRepository.save(expected);
+                    updated++;
+                }
+            }
+            page++;
+        } while (result.hasNext());
+
+        log.info("backfill venues: {} criadas, {} atualizadas, {} ignoradas", created, updated, ignored);
+    }
+}

--- a/src/main/java/br/com/flagplatform/venue/firestore/VenueFirestoreDocument.java
+++ b/src/main/java/br/com/flagplatform/venue/firestore/VenueFirestoreDocument.java
@@ -1,0 +1,87 @@
+package br.com.flagplatform.venue.firestore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Documento próprio do domínio Venue no Firestore (ADR-006) — espelho da
+ * entidade JPA {@code VenueEntity} em campos camelCase. NUNCA persistir a
+ * entidade JPA diretamente: o espelho usa este mapa próprio, estável para os apps
+ * (referee_app/public_app) que lerem a coleção {@code venues} em realtime.
+ *
+ * <p>Tipos serializados (mapa simples, compatível com JSON):
+ * <ul>
+ *   <li>{@code id}/{@code createdBy}/{@code updatedBy}: UUID como {@code String};</li>
+ *   <li>{@code createdAt}/{@code updatedAt}: {@code LocalDateTime} como ISO-8601
+ *       ({@code LocalDateTime.toString()});</li>
+ *   <li>demais campos: {@code String} ou ausentes quando {@code null}.</li>
+ * </ul>
+ *
+ * <p>Campos {@code null} são omitidos do documento ({@link #toMap()}) — o Firestore
+ * não armazena {@code null} e o {@code set(Map)} substitui o documento inteiro,
+ * removendo campos que deixaram de existir. A omissão consistente de {@code null}
+ * também garante a idempotência do backfill ({@code expected.equals(current)}).
+ *
+ * @param id        id UUID do venue ({@code UUID.toString()})
+ * @param name      nome do venue
+ * @param address   endereço (opcional)
+ * @param mapsUrl   URL do Google Maps (opcional)
+ * @param createdAt data de criação (ISO-8601)
+ * @param updatedAt data da última atualização (ISO-8601)
+ * @param createdBy id do usuário que criou ({@code UUID.toString()})
+ * @param updatedBy id do usuário que atualizou ({@code UUID.toString()})
+ */
+public record VenueFirestoreDocument(
+        String id,
+        String name,
+        String address,
+        String mapsUrl,
+        String createdAt,
+        String updatedAt,
+        String createdBy,
+        String updatedBy
+) {
+
+    /**
+     * Converte o snapshot lido do Firestore (mapa) de volta para o documento.
+     * Campos ausentes viram {@code null}.
+     */
+    public static VenueFirestoreDocument fromMap(Map<String, Object> data) {
+        if (data == null || data.isEmpty()) {
+            return null;
+        }
+        return new VenueFirestoreDocument(
+                (String) data.get("id"),
+                (String) data.get("name"),
+                (String) data.get("address"),
+                (String) data.get("mapsUrl"),
+                (String) data.get("createdAt"),
+                (String) data.get("updatedAt"),
+                (String) data.get("createdBy"),
+                (String) data.get("updatedBy"));
+    }
+
+    /**
+     * Converte o documento para o mapa gravado no Firestore, omitindo campos
+     * {@code null} (o Firestore não armazena null e o {@code set(Map)} sobrescreve
+     * o documento inteiro, removendo campos que deixaram de existir).
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> data = new HashMap<>();
+        putIfNotNull(data, "id", id);
+        putIfNotNull(data, "name", name);
+        putIfNotNull(data, "address", address);
+        putIfNotNull(data, "mapsUrl", mapsUrl);
+        putIfNotNull(data, "createdAt", createdAt);
+        putIfNotNull(data, "updatedAt", updatedAt);
+        putIfNotNull(data, "createdBy", createdBy);
+        putIfNotNull(data, "updatedBy", updatedBy);
+        return data;
+    }
+
+    private static void putIfNotNull(Map<String, Object> data, String key, String value) {
+        if (value != null) {
+            data.put(key, value);
+        }
+    }
+}

--- a/src/main/java/br/com/flagplatform/venue/firestore/VenueFirestoreMapper.java
+++ b/src/main/java/br/com/flagplatform/venue/firestore/VenueFirestoreMapper.java
@@ -1,0 +1,28 @@
+package br.com.flagplatform.venue.firestore;
+
+import br.com.flagplatform.venue.entity.VenueEntity;
+import org.mapstruct.Mapper;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Mapeia {@link VenueEntity} (JPA) → {@link VenueFirestoreDocument}
+ * (espelho Firestore, ADR-006). Conversões próprias do domínio, em campos camelCase.
+ *
+ * <p>UUIDs e {@link LocalDateTime} viram {@code String} para manter o documento
+ * simples e JSON-friendly — ver {@link VenueFirestoreDocument}.
+ */
+@Mapper(componentModel = "spring")
+public interface VenueFirestoreMapper {
+
+    VenueFirestoreDocument toDocument(VenueEntity entity);
+
+    default String map(UUID value) {
+        return value == null ? null : value.toString();
+    }
+
+    default String map(LocalDateTime value) {
+        return value == null ? null : value.toString();
+    }
+}

--- a/src/main/java/br/com/flagplatform/venue/firestore/VenueFirestoreRepository.java
+++ b/src/main/java/br/com/flagplatform/venue/firestore/VenueFirestoreRepository.java
@@ -1,0 +1,93 @@
+package br.com.flagplatform.venue.firestore;
+
+import br.com.flagplatform.common.firebase.FirestoreRepository;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.QuerySnapshot;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Implementação Firestore do domínio Venue (ADR-006) — espelho de escrita da
+ * persistência dual (issue #8, seguindo o piloto Organization da issue #7).
+ * Ativada apenas quando {@code app.firestore.venue=true} (e, por consequência,
+ * {@code app.firestore.enabled=true} para existir o bean {@link Firestore}
+ * do {@code FirestoreFactory}).
+ *
+ * <p>Este repositório é o <b>espelho de escrita</b> no Firestore: as leituras do
+ * fluxo REST continuam no PostgreSQL/JPA (fonte autoritativa) e a escrita é dupla
+ * (JPA + Firestore) — ver {@code DualVenueStore}. O tipo da porta é o
+ * {@link VenueFirestoreDocument} (mapa próprio do domínio), nunca a entidade JPA.
+ *
+ * <p>Publica todos os dados do venue na coleção {@code venues}; id do
+ * documento = {@code UUID.toString()}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.venue", havingValue = "true")
+public class VenueFirestoreRepository implements FirestoreRepository<VenueFirestoreDocument> {
+
+    public static final String COLLECTION = "venues";
+
+    private static final long OPERATION_TIMEOUT_SECONDS = 30;
+
+    private final Firestore firestore;
+
+    @Override
+    public Optional<VenueFirestoreDocument> findById(String id) {
+        DocumentSnapshot snapshot = await(firestore.collection(COLLECTION).document(id).get(), "ler");
+        if (!snapshot.exists()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(VenueFirestoreDocument.fromMap(snapshot.getData()));
+    }
+
+    @Override
+    public List<VenueFirestoreDocument> findAll() {
+        QuerySnapshot snapshots = await(firestore.collection(COLLECTION).get(), "listar");
+        return snapshots.getDocuments().stream()
+                .map(DocumentSnapshot::getData)
+                .map(VenueFirestoreDocument::fromMap)
+                .toList();
+    }
+
+    @Override
+    public VenueFirestoreDocument save(VenueFirestoreDocument document) {
+        Objects.requireNonNull(document, "document não pode ser nulo");
+        Objects.requireNonNull(document.id(), "id do documento não pode ser nulo");
+        DocumentReference reference = firestore.collection(COLLECTION).document(document.id());
+        await(reference.set(document.toMap()), "gravar");
+        log.debug("Venue espelhado no Firestore (id={})", document.id());
+        return document;
+    }
+
+    @Override
+    public void delete(String id) {
+        await(firestore.collection(COLLECTION).document(id).delete(), "remover");
+    }
+
+    private <T> T await(ApiFuture<T> future, String operation) {
+        try {
+            return future.get(OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    "Interrompido ao " + operation + " no Firestore (coleção venues)", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new IllegalStateException(
+                    "Falha ao " + operation + " no Firestore (coleção venues)", e);
+        }
+    }
+}

--- a/src/main/java/br/com/flagplatform/venue/repository/DualVenueStore.java
+++ b/src/main/java/br/com/flagplatform/venue/repository/DualVenueStore.java
@@ -1,0 +1,60 @@
+package br.com.flagplatform.venue.repository;
+
+import br.com.flagplatform.venue.entity.VenueEntity;
+import br.com.flagplatform.venue.firestore.VenueFirestoreMapper;
+import br.com.flagplatform.venue.firestore.VenueFirestoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementação <b>dual</b> da porta {@link VenueStore} (ADR-006), vigente
+ * quando {@code app.firestore.venue=true}: escrita dupla no PostgreSQL/JPA
+ * (autoritativa) e no Firestore (espelho para os apps), leitura sempre no JPA.
+ *
+ * <p>A escrita JPA usa {@code saveAndFlush} para materializar {@code id},
+ * {@code createdAt} e {@code updatedAt} (callbacks {@code @PrePersist}/{@code @PreUpdate})
+ * antes de espelhar no Firestore — o documento espelho reflete exatamente o que o
+ * Postgres registrou. Se o Firestore falhar, a exceção propaga e a transação JPA
+ * faz rollback (persistência dual fail-fast: ou grava nas duas, ou em nenhuma).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.venue", havingValue = "true")
+public class DualVenueStore implements VenueStore {
+
+    private final VenueRepository jpaRepository;
+    private final VenueFirestoreRepository firestoreRepository;
+    private final VenueFirestoreMapper mapper;
+
+    @Override
+    public VenueEntity save(VenueEntity entity) {
+        VenueEntity saved = jpaRepository.saveAndFlush(entity);
+        firestoreRepository.save(mapper.toDocument(saved));
+        log.debug("Venue persistido em dual store (id={})", saved.getId());
+        return saved;
+    }
+
+    @Override
+    public Optional<VenueEntity> findById(UUID id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return jpaRepository.existsById(id);
+    }
+
+    @Override
+    public Page<VenueEntity> findAll(Pageable pageable) {
+        return jpaRepository.findAll(pageable);
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/venue/repository/JpaVenueStore.java
+++ b/src/main/java/br/com/flagplatform/venue/repository/JpaVenueStore.java
@@ -1,0 +1,46 @@
+package br.com.flagplatform.venue.repository;
+
+import br.com.flagplatform.venue.entity.VenueEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementação padrão (default) da porta {@link VenueStore}: delega
+ * integralmente ao repositório JPA/PostgreSQL atual. Vigora enquanto
+ * {@code app.firestore.venue} estiver {@code false} (ou ausente) — ou seja,
+ * comportamento 100% igual ao anterior à migração (ADR-006).
+ */
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.venue", havingValue = "false", matchIfMissing = true)
+public class JpaVenueStore implements VenueStore {
+
+    private final VenueRepository repository;
+
+    @Override
+    public VenueEntity save(VenueEntity entity) {
+        return repository.save(entity);
+    }
+
+    @Override
+    public Optional<VenueEntity> findById(UUID id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return repository.existsById(id);
+    }
+
+    @Override
+    public Page<VenueEntity> findAll(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/venue/repository/VenueStore.java
+++ b/src/main/java/br/com/flagplatform/venue/repository/VenueStore.java
@@ -1,0 +1,32 @@
+package br.com.flagplatform.venue.repository;
+
+import br.com.flagplatform.venue.entity.VenueEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Porta de persistência do domínio Venue (ADR-006). Isola o
+ * {@code VenueService} da tecnologia de armazenamento e viabiliza a
+ * <b>persistência dual</b>: com {@code app.firestore.venue=false} vigora a
+ * implementação JPA/PostgreSQL ({@link JpaVenueStore}, padrão atual); com a
+ * flag {@code true} entra {@link DualVenueStore}, que mantém o PostgreSQL
+ * como escrita autoritativa e espelha toda escrita no Firestore.
+ *
+ * <p>As leituras sempre vêm do PostgreSQL (fonte de verdade); o Firestore é o
+ * espelho/realtime para os apps. Regras de negócio e contrato REST ficam intactos
+ * no service — ele conhece apenas esta porta.
+ */
+public interface VenueStore {
+
+    VenueEntity save(VenueEntity entity);
+
+    Optional<VenueEntity> findById(UUID id);
+
+    boolean existsById(UUID id);
+
+    Page<VenueEntity> findAll(Pageable pageable);
+
+}

--- a/src/main/java/br/com/flagplatform/venue/service/VenueService.java
+++ b/src/main/java/br/com/flagplatform/venue/service/VenueService.java
@@ -9,7 +9,7 @@ import br.com.flagplatform.venue.dto.response.VenueResponse;
 import br.com.flagplatform.venue.entity.VenueEntity;
 import br.com.flagplatform.venue.exception.VenueNotFoundException;
 import br.com.flagplatform.venue.mapper.VenueMapper;
-import br.com.flagplatform.venue.repository.VenueRepository;
+import br.com.flagplatform.venue.repository.VenueStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -25,7 +25,7 @@ import java.util.UUID;
 public class VenueService implements VenueLookup {
 
     private final VenueMapper mapper;
-    private final VenueRepository repository;
+    private final VenueStore repository;
 
     @Transactional
     public VenueResponse create(CreateVenueRequest request) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,6 +23,9 @@ app:
     # Domínio piloto do ADR-006 (issue #7): organizações espelham no Firestore
     # (persistência dual) quando a flag está true — default ON no perfil dev.
     organization: ${FIRESTORE_ORGANIZATION_ENABLED:true}
+    # Issue #8: venues espelham no Firestore (persistência dual) quando true —
+    # default ON no perfil dev.
+    venue: ${FIRESTORE_VENUE_ENABLED:true}
 
 logging:
   level:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,6 +20,8 @@ app:
     enabled: ${FIRESTORE_ENABLED:false}
     # Domínio organization também OFF no perfil local (padrão = sem espelho).
     organization: ${FIRESTORE_ORGANIZATION_ENABLED:false}
+    # Domínio venue também OFF no perfil local (padrão = sem espelho).
+    venue: ${FIRESTORE_VENUE_ENABLED:false}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,8 @@ app:
     # app.firestore.enabled=true (bean Firestore ativo via FirestoreFactory).
     # Issue #7 (piloto): organização espelha no Firestore quando true.
     organization: ${FIRESTORE_ORGANIZATION_ENABLED:false}
+    # Issue #8: campos espelham no Firestore quando true.
+    venue: ${FIRESTORE_VENUE_ENABLED:false}
 
 springdoc:
   api-docs:


### PR DESCRIPTION
**Issue:** #8 — feat: migrar domínio Campos (Venue) para Firestore
**História:** H4 — Domínio Venue (backend)

## Objetivo
Replicar o padrão do piloto Organization (issue #7, ADR-006) para o domínio Venue: PostgreSQL/JPA continua como escrita autoritativa; o Firestore vira **espelho de escrita** (escrito pelo Java) a partir da flag `app.firestore.venue=true` (ON no perfil dev, OFF em local/base).

## Alterações
- **`VenueStore`** (porta) + **`JpaVenueStore`** (default, flag false) + **`DualVenueStore`** (flag true): escrita dupla JPA `saveAndFlush` + Firestore **fail-fast** (ou grava nas duas, ou rollback); leituras sempre JPA.
- **`VenueFirestoreDocument`** (record camelCase: id, name, address, mapsUrl, createdAt, updatedAt, createdBy, updatedBy; **sem** organizationId — o domínio backend não tem esse campo); omite nulls → backfill **idempotente**.
- **`VenueFirestoreMapper`** (MapStruct), **`VenueFirestoreRepository`** (coleção `venues`, id = UUID, timeouts 30s) e **`VenueFirestoreBackfill`** (ApplicationRunner, página 500, log `backfill venues: X criadas, Y atualizadas, Z ignoradas`).
- **`VenueService`**: apenas 2 linhas (injetar `VenueStore`); controller/DTOs/entidade/migrações **intactos**.
- Flags: `venue: ${FIRESTORE_VENUE_ENABLED:false}` (base/local), default `true` no dev (emulador localhost:9090).

## Escopo preservado
Sem geração de jogos, sem regras de disponibilidade, sem mudança de contrato REST. `VenueRepository` (Spring Data) segue usado pelos stores e backfill.

## Validação
- `mvnw clean compile` → **BUILD SUCCESS** (validado independentemente pelo tech-lead).
- Padrão verificado contra o piloto #7 (mesma estrutura porta/dual/backfill).

Closes #8