### PR TITLE
feat(#9): migrar domínio Competições para Firestore (persistência dual)

### DIFF
--- a/src/main/java/br/com/flagplatform/competition/firestore/CompetitionFirestoreBackfill.java
+++ b/src/main/java/br/com/flagplatform/competition/firestore/CompetitionFirestoreBackfill.java
@@ -1,0 +1,77 @@
+package br.com.flagplatform.competition.firestore;
+
+import br.com.flagplatform.competition.entity.CompetitionEntity;
+import br.com.flagplatform.competition.repository.CompetitionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Backfill one-shot do domínio Competition (ADR-006): copia os campeonatos do
+ * PostgreSQL (fonte autoritativa) para o Firestore de forma <b>idempotente</b> —
+ * seguindo o piloto Organization (issue #7) e Venue (issue #8). Ativado apenas
+ * quando {@code app.firestore.competition=true} (perfil dev).
+ *
+ * <p>Regra por campeonato (comparando o documento atual do Firestore com o esperado):
+ * <ul>
+ *   <li>documento inexistente → cria;</li>
+ *   <li>documento diferente → sobrescreve (atualiza);</li>
+ *   <li>documento idêntico → ignora (não duplica nem regrava).</li>
+ * </ul>
+ *
+ * <p>Pode rodar repetidas vezes sem efeito colateral; ao final registra a contagem
+ * {@code backfill competitions: X criadas, Y atualizadas, Z ignoradas}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.competition", havingValue = "true")
+public class CompetitionFirestoreBackfill implements ApplicationRunner {
+
+    private static final int PAGE_SIZE = 500;
+
+    private final CompetitionRepository jpaRepository;
+    private final CompetitionFirestoreRepository firestoreRepository;
+    private final CompetitionFirestoreMapper mapper;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Map<String, CompetitionFirestoreDocument> existing = firestoreRepository.findAll().stream()
+                .collect(Collectors.toMap(CompetitionFirestoreDocument::id, document -> document));
+
+        int created = 0;
+        int updated = 0;
+        int ignored = 0;
+
+        int page = 0;
+        Page<CompetitionEntity> result;
+        do {
+            result = jpaRepository.findAll(PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.ASC, "id")));
+            for (CompetitionEntity entity : result.getContent()) {
+                CompetitionFirestoreDocument expected = mapper.toDocument(entity);
+                CompetitionFirestoreDocument current = existing.get(entity.getId().toString());
+                if (current == null) {
+                    firestoreRepository.save(expected);
+                    created++;
+                } else if (expected.equals(current)) {
+                    ignored++;
+                } else {
+                    firestoreRepository.save(expected);
+                    updated++;
+                }
+            }
+            page++;
+        } while (result.hasNext());
+
+        log.info("backfill competitions: {} criadas, {} atualizadas, {} ignoradas", created, updated, ignored);
+    }
+}

--- a/src/main/java/br/com/flagplatform/competition/firestore/CompetitionFirestoreDocument.java
+++ b/src/main/java/br/com/flagplatform/competition/firestore/CompetitionFirestoreDocument.java
@@ -1,0 +1,124 @@
+package br.com.flagplatform.competition.firestore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Documento próprio do domínio Competition no Firestore (ADR-006) — espelho da
+ * entidade JPA {@code CompetitionEntity} em campos camelCase. NUNCA persistir a
+ * entidade JPA diretamente: o espelho usa este mapa próprio, estável para os apps
+ * (referee_app/public_app) que lerem a coleção {@code competitions} em realtime.
+ *
+ * <p>Tipos serializados (mapa simples, compatível com JSON):
+ * <ul>
+ *   <li>{@code id}/{@code organizationId}/{@code createdBy}/{@code updatedBy}: UUID como
+ *       {@code String};</li>
+ *   <li>{@code modality}/{@code gender}/{@code ageGroup}/{@code status}/{@code groupingType}:
+ *       código do enum (mesmo valor da coluna VARCHAR no PostgreSQL);</li>
+ *   <li>{@code startDate}/{@code endDate}: {@code LocalDate} como ISO-8601
+ *       ({@code yyyy-MM-dd});</li>
+ *   <li>{@code createdAt}/{@code updatedAt}: {@code LocalDateTime} como ISO-8601
+ *       ({@code LocalDateTime.toString()});</li>
+ *   <li>demais campos: {@code String} ou ausentes quando {@code null}.</li>
+ * </ul>
+ *
+ * <p>Campos {@code null} são omitidos do documento ({@link #toMap()}) — o Firestore
+ * não armazena {@code null} e o {@code set(Map)} substitui o documento inteiro,
+ * removendo campos que deixaram de existir. A omissão consistente de {@code null}
+ * também garante a idempotência do backfill ({@code expected.equals(current)}).
+ *
+ * @param id             id UUID do campeonato ({@code UUID.toString()})
+ * @param organizationId id da organização dona ({@code UUID.toString()})
+ * @param modality       modalidade (código)
+ * @param gender         gênero (código)
+ * @param ageGroup       faixa etária (código)
+ * @param name           nome do campeonato
+ * @param description    descrição (opcional)
+ * @param startDate      data de início (ISO-8601)
+ * @param endDate        data de fim (ISO-8601)
+ * @param status         status do campeonato (código)
+ * @param groupingType   rótulo do agrupamento (código, opcional)
+ * @param season         temporada
+ * @param createdAt      data de criação (ISO-8601)
+ * @param updatedAt      data da última atualização (ISO-8601)
+ * @param createdBy      id do usuário que criou ({@code UUID.toString()})
+ * @param updatedBy      id do usuário que atualizou ({@code UUID.toString()})
+ */
+public record CompetitionFirestoreDocument(
+        String id,
+        String organizationId,
+        String modality,
+        String gender,
+        String ageGroup,
+        String name,
+        String description,
+        String startDate,
+        String endDate,
+        String status,
+        String groupingType,
+        String season,
+        String createdAt,
+        String updatedAt,
+        String createdBy,
+        String updatedBy
+) {
+
+    /**
+     * Converte o snapshot lido do Firestore (mapa) de volta para o documento.
+     * Campos ausentes viram {@code null}.
+     */
+    public static CompetitionFirestoreDocument fromMap(Map<String, Object> data) {
+        if (data == null || data.isEmpty()) {
+            return null;
+        }
+        return new CompetitionFirestoreDocument(
+                (String) data.get("id"),
+                (String) data.get("organizationId"),
+                (String) data.get("modality"),
+                (String) data.get("gender"),
+                (String) data.get("ageGroup"),
+                (String) data.get("name"),
+                (String) data.get("description"),
+                (String) data.get("startDate"),
+                (String) data.get("endDate"),
+                (String) data.get("status"),
+                (String) data.get("groupingType"),
+                (String) data.get("season"),
+                (String) data.get("createdAt"),
+                (String) data.get("updatedAt"),
+                (String) data.get("createdBy"),
+                (String) data.get("updatedBy"));
+    }
+
+    /**
+     * Converte o documento para o mapa gravado no Firestore, omitindo campos
+     * {@code null} (o Firestore não armazena null e o {@code set(Map)} sobrescreve
+     * o documento inteiro, removendo campos que deixaram de existir).
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> data = new HashMap<>();
+        putIfNotNull(data, "id", id);
+        putIfNotNull(data, "organizationId", organizationId);
+        putIfNotNull(data, "modality", modality);
+        putIfNotNull(data, "gender", gender);
+        putIfNotNull(data, "ageGroup", ageGroup);
+        putIfNotNull(data, "name", name);
+        putIfNotNull(data, "description", description);
+        putIfNotNull(data, "startDate", startDate);
+        putIfNotNull(data, "endDate", endDate);
+        putIfNotNull(data, "status", status);
+        putIfNotNull(data, "groupingType", groupingType);
+        putIfNotNull(data, "season", season);
+        putIfNotNull(data, "createdAt", createdAt);
+        putIfNotNull(data, "updatedAt", updatedAt);
+        putIfNotNull(data, "createdBy", createdBy);
+        putIfNotNull(data, "updatedBy", updatedBy);
+        return data;
+    }
+
+    private static void putIfNotNull(Map<String, Object> data, String key, String value) {
+        if (value != null) {
+            data.put(key, value);
+        }
+    }
+}

--- a/src/main/java/br/com/flagplatform/competition/firestore/CompetitionFirestoreMapper.java
+++ b/src/main/java/br/com/flagplatform/competition/firestore/CompetitionFirestoreMapper.java
@@ -1,0 +1,96 @@
+package br.com.flagplatform.competition.firestore;
+
+import br.com.flagplatform.common.enums.AgeGroup;
+import br.com.flagplatform.common.enums.CompetitionStatus;
+import br.com.flagplatform.common.enums.Gender;
+import br.com.flagplatform.common.enums.GroupingType;
+import br.com.flagplatform.common.enums.Modality;
+import br.com.flagplatform.competition.entity.CompetitionEntity;
+import org.mapstruct.Mapper;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Mapeia {@link CompetitionEntity} (JPA) ↔ {@link CompetitionFirestoreDocument}
+ * (espelho Firestore, ADR-006). Conversões próprias do domínio, em campos camelCase.
+ *
+ * <p>Enums são gravados pelo {@code code} (mesmo valor da coluna VARCHAR no Postgres,
+ * ex.: {@code DRAFT}, {@code FLAG_5X5}, {@code ADULT}); UUIDs, {@link LocalDateTime} e
+ * {@link LocalDate} viram {@code String} para manter o documento simples e
+ * JSON-friendly — ver {@link CompetitionFirestoreDocument}.
+ */
+@Mapper(componentModel = "spring")
+public interface CompetitionFirestoreMapper {
+
+    CompetitionFirestoreDocument toDocument(CompetitionEntity entity);
+
+    CompetitionEntity toEntity(CompetitionFirestoreDocument document);
+
+    // entity → documento
+    default String map(UUID value) {
+        return value == null ? null : value.toString();
+    }
+
+    default String map(Modality value) {
+        return value == null ? null : value.getCode();
+    }
+
+    default String map(Gender value) {
+        return value == null ? null : value.getCode();
+    }
+
+    default String map(AgeGroup value) {
+        return value == null ? null : value.getCode();
+    }
+
+    default String map(CompetitionStatus value) {
+        return value == null ? null : value.getCode();
+    }
+
+    default String map(GroupingType value) {
+        return value == null ? null : value.getCode();
+    }
+
+    default String map(LocalDate value) {
+        return value == null ? null : value.toString();
+    }
+
+    default String map(LocalDateTime value) {
+        return value == null ? null : value.toString();
+    }
+
+    // documento → entity
+    default UUID mapUuid(String value) {
+        return value == null ? null : UUID.fromString(value);
+    }
+
+    default Modality mapModality(String value) {
+        return value == null ? null : Modality.valueOf(value);
+    }
+
+    default Gender mapGender(String value) {
+        return value == null ? null : Gender.valueOf(value);
+    }
+
+    default AgeGroup mapAgeGroup(String value) {
+        return value == null ? null : AgeGroup.valueOf(value);
+    }
+
+    default CompetitionStatus mapCompetitionStatus(String value) {
+        return value == null ? null : CompetitionStatus.valueOf(value);
+    }
+
+    default GroupingType mapGroupingType(String value) {
+        return value == null ? null : GroupingType.valueOf(value);
+    }
+
+    default LocalDate mapLocalDate(String value) {
+        return value == null ? null : LocalDate.parse(value);
+    }
+
+    default LocalDateTime mapLocalDateTime(String value) {
+        return value == null ? null : LocalDateTime.parse(value);
+    }
+}

--- a/src/main/java/br/com/flagplatform/competition/firestore/CompetitionFirestoreRepository.java
+++ b/src/main/java/br/com/flagplatform/competition/firestore/CompetitionFirestoreRepository.java
@@ -1,0 +1,93 @@
+package br.com.flagplatform.competition.firestore;
+
+import br.com.flagplatform.common.firebase.FirestoreRepository;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.QuerySnapshot;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Implementação Firestore do domínio Competition (ADR-006) — espelho de escrita da
+ * persistência dual (issue #9, seguindo o piloto Organization da issue #7 e Venue da
+ * issue #8). Ativada apenas quando {@code app.firestore.competition=true} (e, por
+ * consequência, {@code app.firestore.enabled=true} para existir o bean {@link Firestore}
+ * do {@code FirestoreFactory}).
+ *
+ * <p>Este repositório é o <b>espelho de escrita</b> no Firestore: as leituras do
+ * fluxo REST continuam no PostgreSQL/JPA (fonte autoritativa) e a escrita é dupla
+ * (JPA + Firestore) — ver {@code DualCompetitionStore}. O tipo da porta é o
+ * {@link CompetitionFirestoreDocument} (mapa próprio do domínio), nunca a entidade JPA.
+ *
+ * <p>Publica todos os dados do campeonato na coleção {@code competitions}; id do
+ * documento = {@code UUID.toString()}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.competition", havingValue = "true")
+public class CompetitionFirestoreRepository implements FirestoreRepository<CompetitionFirestoreDocument> {
+
+    public static final String COLLECTION = "competitions";
+
+    private static final long OPERATION_TIMEOUT_SECONDS = 30;
+
+    private final Firestore firestore;
+
+    @Override
+    public Optional<CompetitionFirestoreDocument> findById(String id) {
+        DocumentSnapshot snapshot = await(firestore.collection(COLLECTION).document(id).get(), "ler");
+        if (!snapshot.exists()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(CompetitionFirestoreDocument.fromMap(snapshot.getData()));
+    }
+
+    @Override
+    public List<CompetitionFirestoreDocument> findAll() {
+        QuerySnapshot snapshots = await(firestore.collection(COLLECTION).get(), "listar");
+        return snapshots.getDocuments().stream()
+                .map(DocumentSnapshot::getData)
+                .map(CompetitionFirestoreDocument::fromMap)
+                .toList();
+    }
+
+    @Override
+    public CompetitionFirestoreDocument save(CompetitionFirestoreDocument document) {
+        Objects.requireNonNull(document, "document não pode ser nulo");
+        Objects.requireNonNull(document.id(), "id do documento não pode ser nulo");
+        DocumentReference reference = firestore.collection(COLLECTION).document(document.id());
+        await(reference.set(document.toMap()), "gravar");
+        log.debug("Competition espelhado no Firestore (id={})", document.id());
+        return document;
+    }
+
+    @Override
+    public void delete(String id) {
+        await(firestore.collection(COLLECTION).document(id).delete(), "remover");
+    }
+
+    private <T> T await(ApiFuture<T> future, String operation) {
+        try {
+            return future.get(OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    "Interrompido ao " + operation + " no Firestore (coleção competitions)", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new IllegalStateException(
+                    "Falha ao " + operation + " no Firestore (coleção competitions)", e);
+        }
+    }
+}

--- a/src/main/java/br/com/flagplatform/competition/repository/CompetitionStore.java
+++ b/src/main/java/br/com/flagplatform/competition/repository/CompetitionStore.java
@@ -1,0 +1,43 @@
+package br.com.flagplatform.competition.repository;
+
+import br.com.flagplatform.common.enums.CompetitionStatus;
+import br.com.flagplatform.competition.entity.CompetitionEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Porta de persistência do domínio Competition (ADR-006). Isola o
+ * {@code CompetitionService} da tecnologia de armazenamento e viabiliza a
+ * <b>persistência dual</b>: com {@code app.firestore.competition=false} vigora a
+ * implementação JPA/PostgreSQL ({@link JpaCompetitionStore}, padrão atual); com a
+ * flag {@code true} entra {@link DualCompetitionStore}, que mantém o PostgreSQL
+ * como escrita autoritativa e espelha toda escrita no Firestore.
+ *
+ * <p>As leituras sempre vêm do PostgreSQL (fonte de verdade); o Firestore é o
+ * espelho/realtime para os apps. Regras de negócio e contrato REST ficam intactos
+ * no service — ele conhece apenas esta porta.
+ */
+public interface CompetitionStore {
+
+    CompetitionEntity save(CompetitionEntity entity);
+
+    Optional<CompetitionEntity> findById(UUID id);
+
+    List<CompetitionEntity> findAllById(Collection<UUID> ids);
+
+    boolean existsByOrganizationIdAndNameIgnoreCase(UUID organizationId, String name);
+
+    boolean existsByOrganizationIdAndNameIgnoreCaseAndIdNot(UUID organizationId, String name, UUID id);
+
+    List<CompetitionEntity> findAllByOrganizationIdOrderByNameAsc(UUID organizationId);
+
+    Page<CompetitionEntity> findAll(Pageable pageable);
+
+    Page<CompetitionEntity> findAllByStatusNot(CompetitionStatus status, Pageable pageable);
+
+}

--- a/src/main/java/br/com/flagplatform/competition/repository/DualCompetitionStore.java
+++ b/src/main/java/br/com/flagplatform/competition/repository/DualCompetitionStore.java
@@ -1,0 +1,83 @@
+package br.com.flagplatform.competition.repository;
+
+import br.com.flagplatform.common.enums.CompetitionStatus;
+import br.com.flagplatform.competition.entity.CompetitionEntity;
+import br.com.flagplatform.competition.firestore.CompetitionFirestoreMapper;
+import br.com.flagplatform.competition.firestore.CompetitionFirestoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementação <b>dual</b> da porta {@link CompetitionStore} (ADR-006), vigente
+ * quando {@code app.firestore.competition=true}: escrita dupla no PostgreSQL/JPA
+ * (autoritativa) e no Firestore (espelho para os apps), leitura sempre no JPA.
+ *
+ * <p>A escrita JPA usa {@code saveAndFlush} para materializar {@code id},
+ * {@code createdAt} e {@code updatedAt} (callbacks {@code @PrePersist}/{@code @PreUpdate})
+ * antes de espelhar no Firestore — o documento espelho reflete exatamente o que o
+ * Postgres registrou. Se o Firestore falhar, a exceção propaga e a transação JPA
+ * faz rollback (persistência dual fail-fast: ou grava nas duas, ou em nenhuma).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.competition", havingValue = "true")
+public class DualCompetitionStore implements CompetitionStore {
+
+    private final CompetitionRepository jpaRepository;
+    private final CompetitionFirestoreRepository firestoreRepository;
+    private final CompetitionFirestoreMapper mapper;
+
+    @Override
+    public CompetitionEntity save(CompetitionEntity entity) {
+        CompetitionEntity saved = jpaRepository.saveAndFlush(entity);
+        firestoreRepository.save(mapper.toDocument(saved));
+        log.debug("Competition persistido em dual store (id={})", saved.getId());
+        return saved;
+    }
+
+    @Override
+    public Optional<CompetitionEntity> findById(UUID id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<CompetitionEntity> findAllById(Collection<UUID> ids) {
+        return jpaRepository.findAllById(ids);
+    }
+
+    @Override
+    public boolean existsByOrganizationIdAndNameIgnoreCase(UUID organizationId, String name) {
+        return jpaRepository.existsByOrganizationIdAndNameIgnoreCase(organizationId, name);
+    }
+
+    @Override
+    public boolean existsByOrganizationIdAndNameIgnoreCaseAndIdNot(UUID organizationId, String name, UUID id) {
+        return jpaRepository.existsByOrganizationIdAndNameIgnoreCaseAndIdNot(organizationId, name, id);
+    }
+
+    @Override
+    public List<CompetitionEntity> findAllByOrganizationIdOrderByNameAsc(UUID organizationId) {
+        return jpaRepository.findAllByOrganizationIdOrderByNameAsc(organizationId);
+    }
+
+    @Override
+    public Page<CompetitionEntity> findAll(Pageable pageable) {
+        return jpaRepository.findAll(pageable);
+    }
+
+    @Override
+    public Page<CompetitionEntity> findAllByStatusNot(CompetitionStatus status, Pageable pageable) {
+        return jpaRepository.findAllByStatusNot(status, pageable);
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/competition/repository/JpaCompetitionStore.java
+++ b/src/main/java/br/com/flagplatform/competition/repository/JpaCompetitionStore.java
@@ -1,0 +1,69 @@
+package br.com.flagplatform.competition.repository;
+
+import br.com.flagplatform.common.enums.CompetitionStatus;
+import br.com.flagplatform.competition.entity.CompetitionEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementação padrão (default) da porta {@link CompetitionStore}: delega
+ * integralmente ao repositório JPA/PostgreSQL atual. Vigora enquanto
+ * {@code app.firestore.competition} estiver {@code false} (ou ausente) — ou seja,
+ * comportamento 100% igual ao anterior à migração (ADR-006).
+ */
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.competition", havingValue = "false", matchIfMissing = true)
+public class JpaCompetitionStore implements CompetitionStore {
+
+    private final CompetitionRepository repository;
+
+    @Override
+    public CompetitionEntity save(CompetitionEntity entity) {
+        return repository.save(entity);
+    }
+
+    @Override
+    public Optional<CompetitionEntity> findById(UUID id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public List<CompetitionEntity> findAllById(Collection<UUID> ids) {
+        return repository.findAllById(ids);
+    }
+
+    @Override
+    public boolean existsByOrganizationIdAndNameIgnoreCase(UUID organizationId, String name) {
+        return repository.existsByOrganizationIdAndNameIgnoreCase(organizationId, name);
+    }
+
+    @Override
+    public boolean existsByOrganizationIdAndNameIgnoreCaseAndIdNot(UUID organizationId, String name, UUID id) {
+        return repository.existsByOrganizationIdAndNameIgnoreCaseAndIdNot(organizationId, name, id);
+    }
+
+    @Override
+    public List<CompetitionEntity> findAllByOrganizationIdOrderByNameAsc(UUID organizationId) {
+        return repository.findAllByOrganizationIdOrderByNameAsc(organizationId);
+    }
+
+    @Override
+    public Page<CompetitionEntity> findAll(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    @Override
+    public Page<CompetitionEntity> findAllByStatusNot(CompetitionStatus status, Pageable pageable) {
+        return repository.findAllByStatusNot(status, pageable);
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/competition/service/CompetitionService.java
+++ b/src/main/java/br/com/flagplatform/competition/service/CompetitionService.java
@@ -16,7 +16,7 @@ import br.com.flagplatform.competition.exception.CompetitionNotFinishableExcepti
 import br.com.flagplatform.competition.exception.CompetitionNotOwnedByCreatorException;
 import br.com.flagplatform.competition.exception.DuplicateCompetitionNameException;
 import br.com.flagplatform.competition.mapper.CompetitionMapper;
-import br.com.flagplatform.competition.repository.CompetitionRepository;
+import br.com.flagplatform.competition.repository.CompetitionStore;
 import br.com.flagplatform.competition.CompetitionCreatedEvent;
 import br.com.flagplatform.organization.OrganizationLookup;
 import br.com.flagplatform.user.UserLookup;
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 public class CompetitionService implements CompetitionLookup {
 
     private final CompetitionMapper mapper;
-    private final CompetitionRepository repository;
+    private final CompetitionStore repository;
     private final OrganizationLookup organizationLookup;
     private final UserLookup userLookup;
     private final ApplicationEventPublisher events;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,6 +26,9 @@ app:
     # Issue #8: venues espelham no Firestore (persistência dual) quando true —
     # default ON no perfil dev.
     venue: ${FIRESTORE_VENUE_ENABLED:true}
+    # Issue #9: campeonatos espelham no Firestore (persistência dual) quando true —
+    # default ON no perfil dev.
+    competition: ${FIRESTORE_COMPETITION_ENABLED:true}
 
 logging:
   level:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,6 +22,8 @@ app:
     organization: ${FIRESTORE_ORGANIZATION_ENABLED:false}
     # Domínio venue também OFF no perfil local (padrão = sem espelho).
     venue: ${FIRESTORE_VENUE_ENABLED:false}
+    # Domínio competition também OFF no perfil local (padrão = sem espelho).
+    competition: ${FIRESTORE_COMPETITION_ENABLED:false}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,6 +90,8 @@ app:
     organization: ${FIRESTORE_ORGANIZATION_ENABLED:false}
     # Issue #8: campos espelham no Firestore quando true.
     venue: ${FIRESTORE_VENUE_ENABLED:false}
+    # Issue #9: campeonatos espelham no Firestore quando true.
+    competition: ${FIRESTORE_COMPETITION_ENABLED:false}
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## H5 — Migrar domínio Competições para Firestore (persistência dual, ADR-006)

Closes #9

Segue o padrão H3/H4 (Organization/Venue): PostgreSQL/JPA continua a fonte de verdade; Firestore é espelho de escrita para os apps (read-realtime), habilitado por flag por domínio.

### Mudanças

**Porta de repositório (`competition/repository/`)**
- `CompetitionStore` — nova porta com as operações usadas pelo service (`save`, `findById`, `findAllById`, `exists...`, `findAll...`, `findAllByStatusNot`).
- `JpaCompetitionStore` — implementação JPA vigente com `app.firestore.competition=false`.
- `DualCompetitionStore` — escrita dual fail-fast (`saveAndFlush` JPA → espelho Firestore; falha no Firestore propaga e rolla a transação). Leitura sempre no JPA.

**Firestore (`competition/firestore/`)**
- `CompetitionFirestoreDocument` — record-espelho camelCase, `fromMap`/`toMap` omitindo `null` (idempotência do backfill).
- `CompetitionFirestoreMapper` — MapStruct JPA↔Firestore (enums via `code`, UUID/datas como String).
- `CompetitionFirestoreRepository` — escrita na coleção `competitions` (id = `UUID.toString()`), ativo com a flag `true`, timeout 30s.
- `CompetitionFirestoreBackfill` — one-shot idempotente paginado (cria/atualiza/ignora), log resumido.

**Wiring/flags**
- `CompetitionService` passa a injetar `CompetitionStore` (contrato REST inalterado).
- `application.yml` (base) e `application-local.yml`: `competition: ${FIRESTORE_COMPETITION_ENABLED:false}`.
- `application-dev.yml`: `competition: ${FIRESTORE_COMPETITION_ENABLED:true}` (emulador localhost:9090).

### Validação
- `./mvnw.cmd clean compile` → BUILD SUCCESS (EXIT 0).
- Divergências do padrão H3/H4 resolvidas: `LocalDate` (startDate/endDate ISO), 5 enums (Modality, Gender, AgeGroup, CompetitionStatus, GroupingType), `findAllById` na porta (batch do `findCompetitionInfoByIds`).

**Não escopo:** contrato REST; regras de negócio; outros domínios; frontend (admin web permanece 100% REST — ver #70).

## Workflow
GitFlow: branch `feature/issue-9-firestore-competitions` → `develop`. Squash merge.