### PR TITLE
docs(#24): ADR-001/006 — Admin Web lê somente via REST

### DIFF
--- a/docs/adr/001-backend-architecture-java-firebase.md
+++ b/docs/adr/001-backend-architecture-java-firebase.md
@@ -61,18 +61,30 @@ O Flag Platform precisa de uma arquitetura backend que suporte:
 ## Fluxo de Dados
 
 ```
-Flutter Web
+Flag Admin Web (flag_admin_web)
     │
-    ├──→ Firebase Auth (login/logout)
+    ├──→ Firebase Auth (login/logout — ÚNICO acesso direto ao Firebase)
     │
-    └──→ Java API REST
+    └──→ Java API REST (todas as demais operações — listagens, detalhes e escrita)
               │
               ├──→ Regras de negócio (eligibility, standings)
               │
-              └──→ Firebase Firestore (leitura/escrita)
+              └──→ Firebase Firestore (leitura/escrita via backend/Admin SDK)
                         │
                         └──→ Firebase Storage (imagens)
+
+App do torcedor / árbitro (public_app, referee_app)
+    │
+    ├──→ Firebase Auth (login)
+    ├──→ Firebase Firestore (leitura realtime — via espelho do backend)
+    │
+    └──→ Java API REST (operações de escrita)
 ```
+
+> **Regra (2026-09-05):** o Admin Web acessa o Firebase **somente para autenticação**
+> (Firebase Auth). **Todos os demais cenários passam pelo backend (REST) sempre** — o Admin
+> Web nunca lê nem escreve no Firestore diretamente. O Firestore é espelho de leitura realtime
+> **apenas** para os apps (public_app/referee_app); o backend segue como única porta de escrita.
 
 ## Consequências
 

--- a/docs/adr/006-firestore-incremental-migration.md
+++ b/docs/adr/006-firestore-incremental-migration.md
@@ -24,18 +24,23 @@ negócio, controllers, JPA ou Flyway.
 2. **Escrita única via Java REST**: o **cliente web NÃO escreve direto no Firestore**. Toda
    escrita passa pelo backend (Admin SDK). O Firestore é persistência/leitura (realtime) para
    os apps (referee_app, public_app), nunca porta de escrita do cliente.
-3. **Padrão porta de repositório**: interface-base genérica
+3. **Admin Web lê somente via REST**: o Admin Web (flag_admin_web) lê listagens/detalhes
+   **exclusivamente** pela API REST do backend — exceto **Firebase Auth** para login. Ele NÃO
+   consome o Firestore diretamente (nem leitura). O Firestore é espelho de leitura realtime
+   **apenas** para os apps (public_app/referee_app); o backend continua sendo a única porta de
+   escrita (Admin SDK). Nenhuma etapa futura troca datasource do Admin Web para Firestore.
+4. **Padrão porta de repositório**: interface-base genérica
    `br.com.flagplatform.common.firebase.FirestoreRepository<T>` (`findById`, `findAll`,
    `save`, `delete`). Domínios migrados implementam:
    `XxxFirestoreRepository implements XxxRepository, FirestoreRepository<XxxEntity>` com
    `@ConditionalOnProperty(name = "app.firestore.<domínio>", havingValue = "true")`.
    A interface `XxxRepository` (JPA) não muda; a troca de implementação é transparente para o service.
-4. **Emulador no perfil dev**: `FirestoreFactory` cria o bean `Firestore` apenas quando
+5. **Emulador no perfil dev**: `FirestoreFactory` cria o bean `Firestore` apenas quando
    `app.firestore.enabled=true` (`@ConditionalOnProperty`). Com host de emulador configurado,
    usa `FirestoreOptions.setEmulatorHost(...)` + `EmulatorCredentials` (sem credencial real).
    Sem host, usa a API real com service account (`FIREBASE_SERVICE_ACCOUNT` /
    `GOOGLE_APPLICATION_CREDENTIALS` / ADC).
-5. **Regras de segurança Firestore**: leitura pública/autenticada por regras; escrita SOMENTE
+6. **Regras de segurança Firestore**: leitura pública/autenticada por regras; escrita SOMENTE
    via Admin SDK (Java). Regras a publicar junto com o primeiro domínio migrado.
 
 ## Configuração (env vars)


### PR DESCRIPTION
## ADR-006/001 — Admin Web lê somente via REST (Firestore só para apps)

Closes #24

### Contexto

Decisão de arquitetura 2026-09-05: o Admin Web acessa o Firebase **apenas para autenticação** (Firebase Auth); **todos os demais cenários passam pelo backend (REST) sempre**. O Firestore é espelho de leitura realtime **somente para os apps** (public_app/referee_app) — nunca porta de leitura do admin web. Fecha a ambiguidade que causou o desvio #52/#53 (web lendo Firestore direto) e embute a regra para as próximas etapas.

### Mudanças

- **ADR-006** (`006-firestore-incremental-migration.md`): novo item na Decisão — *"Admin Web lê somente via REST"* (leitura exclusiva REST; Firestore espelho apenas para apps; nenhuma etapa futura troca datasource do admin web para Firestore). Itens subsequentes renumerados.
- **ADR-001** (`001-backend-architecture-java-firebase.md`): Fluxo de Dados atualizado — separa **Flag Admin Web** (Firebase Auth exclusivo p/ login; todo o resto via Java API REST → regras → Firestore/Storage via Admin SDK) e **apps** (public_app/referee_app: Firebase Auth + leitura realtime do espelho Firestore + escrita via REST); nota explícita da regra.

### Validação
- Apenas documentação (sem mudança de código).
- Commit: `8459ba9`.

## Workflow
GitFlow: branch `chore/issue-24-adr-rest-admin-web` → `develop`. Squash merge.