### PR TITLE
feat(#10): Conferências e Divisões espelham no Firestore (dual, ADR-006)

### DIFF
--- a/docs/adr/006-firestore-incremental-migration.md
+++ b/docs/adr/006-firestore-incremental-migration.md
@@ -43,6 +43,40 @@ negócio, controllers, JPA ou Flyway.
 6. **Regras de segurança Firestore**: leitura pública/autenticada por regras; escrita SOMENTE
    via Admin SDK (Java). Regras a publicar junto com o primeiro domínio migrado.
 
+## Modelagem no Firestore: flat vs aninhada (Issue #10)
+
+Para os domínios migrados até aqui (organization/issue #7, venue/issue #8,
+competition/issue #9 e agora conference/division na issue #10), a modelagem adotada é
+**flat**: cada domínio tem **coleção própria no nível raiz** (`organizations`, `venues`,
+`competitions`, `conferences`, `divisions`) e o documento é identificado pelo
+`UUID.toString()` da entidade JPA. Relacionamentos são expressos por **campos de
+referência** — a conferência carrega `competitionId`; a divisão carrega `competitionId` e,
+opcionalmente, `conferenceId` — nunca por subcoleções aninhadas
+(ex.: {`competitions/{id}/conferences/...`}).
+
+**Decisão para conference/division: flat (coleções próprias)**, coerente com o padrão já
+estabelecido. Justificativa:
+
+1. **Uniformidade com o padrão existente**: org/venue/competition já usam coleções próprias
+   flat; manter conference/division no mesmo formato dá um único padrão de código, regras de
+   segurança e consultas nos apps.
+2. **Document id universal**: o documento usa o mesmo UUID da entidade JPA (fonte de
+   verdade). Em modelagem aninhada, o caminho do documento ficaria subordinado ao id da
+   competição, complicando referências cruzadas (uma divisão pertence a uma conferência
+   opcional e sempre a uma competição).
+3. **Escritas independentes e idempotentes**: conferência e divisão são criadas/atualizadas/
+   excluídas individualmente; a modelagem flat espelha cada operação da porta de repositório
+   sem reescrever subárvores inteiras (evita gravação em cascata e risco de divergência).
+4. **Consultas dos apps**: os apps leem conferências por `competitionId` e divisões por
+   `competitionId`/`conferenceId` — no Firestore isso é uma query simples por campo
+   (`where("competitionId", "==", id)`), sem composite paths.
+5. **Regras de segurança simples**: uma coleção por domínio com leitura pública/autenticada é
+   mais fácil de auditar do que regras por caminho aninhado.
+
+**Consequência**: o documento Firestore reflete os mesmos campos camelCase da API REST
+(UUIDs como string, timestamps ISO-8601), mantendo o espelho consumível pelos apps
+(referee_app/public_app) sem transformação adicional.
+
 ## Configuração (env vars)
 
 | Variável | Default | Uso |

--- a/src/main/java/br/com/flagplatform/conference/firestore/ConferenceFirestoreBackfill.java
+++ b/src/main/java/br/com/flagplatform/conference/firestore/ConferenceFirestoreBackfill.java
@@ -1,0 +1,77 @@
+package br.com.flagplatform.conference.firestore;
+
+import br.com.flagplatform.conference.entity.ConferenceEntity;
+import br.com.flagplatform.conference.repository.ConferenceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Backfill one-shot do domínio Conference (ADR-006): copia as conferências do
+ * PostgreSQL (fonte autoritativa) para o Firestore de forma <b>idempotente</b> —
+ * seguindo o padrão de Organization (issue #7), Venue (issue #8) e Competition
+ * (issue #9). Ativado apenas quando {@code app.firestore.conference=true} (perfil dev).
+ *
+ * <p>Regra por conferência (comparando o documento atual do Firestore com o esperado):
+ * <ul>
+ *   <li>documento inexistente → cria;</li>
+ *   <li>documento diferente → sobrescreve (atualiza);</li>
+ *   <li>documento idêntico → ignora (não duplica nem regrava).</li>
+ * </ul>
+ *
+ * <p>Pode rodar repetidas vezes sem efeito colateral; ao final registra a contagem
+ * {@code backfill conferences: X criadas, Y atualizadas, Z ignoradas}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.conference", havingValue = "true")
+public class ConferenceFirestoreBackfill implements ApplicationRunner {
+
+    private static final int PAGE_SIZE = 500;
+
+    private final ConferenceRepository jpaRepository;
+    private final ConferenceFirestoreRepository firestoreRepository;
+    private final ConferenceFirestoreMapper mapper;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Map<String, ConferenceFirestoreDocument> existing = firestoreRepository.findAll().stream()
+                .collect(Collectors.toMap(ConferenceFirestoreDocument::id, document -> document));
+
+        int created = 0;
+        int updated = 0;
+        int ignored = 0;
+
+        int page = 0;
+        Page<ConferenceEntity> result;
+        do {
+            result = jpaRepository.findAll(PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.ASC, "id")));
+            for (ConferenceEntity entity : result.getContent()) {
+                ConferenceFirestoreDocument expected = mapper.toDocument(entity);
+                ConferenceFirestoreDocument current = existing.get(entity.getId().toString());
+                if (current == null) {
+                    firestoreRepository.save(expected);
+                    created++;
+                } else if (expected.equals(current)) {
+                    ignored++;
+                } else {
+                    firestoreRepository.save(expected);
+                    updated++;
+                }
+            }
+            page++;
+        } while (result.hasNext());
+
+        log.info("backfill conferences: {} criadas, {} atualizadas, {} ignoradas", created, updated, ignored);
+    }
+}

--- a/src/main/java/br/com/flagplatform/conference/firestore/ConferenceFirestoreDocument.java
+++ b/src/main/java/br/com/flagplatform/conference/firestore/ConferenceFirestoreDocument.java
@@ -1,0 +1,88 @@
+package br.com.flagplatform.conference.firestore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Documento próprio do domínio Conference no Firestore (ADR-006) — espelho da
+ * entidade JPA {@code ConferenceEntity} em campos camelCase. NUNCA persistir a
+ * entidade JPA diretamente: o espelho usa este mapa próprio, estável para os apps
+ * (referee_app/public_app) que lerem a coleção {@code conferences} em realtime.
+ *
+ * <p>Modelagem <b>flat</b> (ADR-006): coleção própria no nível raiz, documento
+ * identificado pelo {@code UUID.toString()} da entidade e o relacionamento expresso
+ * por campo de referência ({@code competitionId}) — sem subcoleções aninhadas.
+ *
+ * <p>Tipos serializados (mapa simples, compatível com JSON):
+ * <ul>
+ *   <li>{@code id}/{@code competitionId}/{@code createdBy}/{@code updatedBy}: UUID como
+ *       {@code String};</li>
+ *   <li>{@code createdAt}/{@code updatedAt}: {@code LocalDateTime} como ISO-8601
+ *       ({@code LocalDateTime.toString()});</li>
+ *   <li>demais campos: {@code String}.</li>
+ * </ul>
+ *
+ * <p>Campos {@code null} são omitidos do documento ({@link #toMap()}) — o Firestore
+ * não armazena {@code null} e o {@code set(Map)} substitui o documento inteiro,
+ * removendo campos que deixaram de existir. A omissão consistente de {@code null}
+ * também garante a idempotência do backfill ({@code expected.equals(current)}).
+ *
+ * @param id             id UUID da conferência ({@code UUID.toString()})
+ * @param competitionId  id do campeonato dono ({@code UUID.toString()})
+ * @param name           nome da conferência
+ * @param createdAt      data de criação (ISO-8601)
+ * @param updatedAt      data da última atualização (ISO-8601)
+ * @param createdBy      id do usuário que criou ({@code UUID.toString()})
+ * @param updatedBy      id do usuário que atualizou ({@code UUID.toString()})
+ */
+public record ConferenceFirestoreDocument(
+        String id,
+        String competitionId,
+        String name,
+        String createdAt,
+        String updatedAt,
+        String createdBy,
+        String updatedBy
+) {
+
+    /**
+     * Converte o snapshot lido do Firestore (mapa) de volta para o documento.
+     * Campos ausentes viram {@code null}.
+     */
+    public static ConferenceFirestoreDocument fromMap(Map<String, Object> data) {
+        if (data == null || data.isEmpty()) {
+            return null;
+        }
+        return new ConferenceFirestoreDocument(
+                (String) data.get("id"),
+                (String) data.get("competitionId"),
+                (String) data.get("name"),
+                (String) data.get("createdAt"),
+                (String) data.get("updatedAt"),
+                (String) data.get("createdBy"),
+                (String) data.get("updatedBy"));
+    }
+
+    /**
+     * Converte o documento para o mapa gravado no Firestore, omitindo campos
+     * {@code null} (o Firestore não armazena null e o {@code set(Map)} sobrescreve
+     * o documento inteiro, removendo campos que deixaram de existir).
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> data = new HashMap<>();
+        putIfNotNull(data, "id", id);
+        putIfNotNull(data, "competitionId", competitionId);
+        putIfNotNull(data, "name", name);
+        putIfNotNull(data, "createdAt", createdAt);
+        putIfNotNull(data, "updatedAt", updatedAt);
+        putIfNotNull(data, "createdBy", createdBy);
+        putIfNotNull(data, "updatedBy", updatedBy);
+        return data;
+    }
+
+    private static void putIfNotNull(Map<String, Object> data, String key, String value) {
+        if (value != null) {
+            data.put(key, value);
+        }
+    }
+}

--- a/src/main/java/br/com/flagplatform/conference/firestore/ConferenceFirestoreMapper.java
+++ b/src/main/java/br/com/flagplatform/conference/firestore/ConferenceFirestoreMapper.java
@@ -1,0 +1,40 @@
+package br.com.flagplatform.conference.firestore;
+
+import br.com.flagplatform.conference.entity.ConferenceEntity;
+import org.mapstruct.Mapper;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Mapeia {@link ConferenceEntity} (JPA) ↔ {@link ConferenceFirestoreDocument}
+ * (espelho Firestore, ADR-006). Conversões próprias do domínio, em campos camelCase.
+ *
+ * <p>UUIDs e {@link LocalDateTime} viram {@code String} para manter o documento
+ * simples e JSON-friendly — ver {@link ConferenceFirestoreDocument}.
+ */
+@Mapper(componentModel = "spring")
+public interface ConferenceFirestoreMapper {
+
+    ConferenceFirestoreDocument toDocument(ConferenceEntity entity);
+
+    ConferenceEntity toEntity(ConferenceFirestoreDocument document);
+
+    // entity → documento
+    default String map(UUID value) {
+        return value == null ? null : value.toString();
+    }
+
+    default String map(LocalDateTime value) {
+        return value == null ? null : value.toString();
+    }
+
+    // documento → entity
+    default UUID mapUuid(String value) {
+        return value == null ? null : UUID.fromString(value);
+    }
+
+    default LocalDateTime mapLocalDateTime(String value) {
+        return value == null ? null : LocalDateTime.parse(value);
+    }
+}

--- a/src/main/java/br/com/flagplatform/conference/firestore/ConferenceFirestoreRepository.java
+++ b/src/main/java/br/com/flagplatform/conference/firestore/ConferenceFirestoreRepository.java
@@ -1,0 +1,93 @@
+package br.com.flagplatform.conference.firestore;
+
+import br.com.flagplatform.common.firebase.FirestoreRepository;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.QuerySnapshot;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Implementação Firestore do domínio Conference (ADR-006) — espelho de escrita da
+ * persistência dual (issue #10, seguindo o padrão de Organization/issue #7, Venue/issue #8
+ * e Competition/issue #9). Ativada apenas quando {@code app.firestore.conference=true}
+ * (e, por consequência, {@code app.firestore.enabled=true} para existir o bean
+ * {@link Firestore} do {@code FirestoreFactory}).
+ *
+ * <p>Este repositório é o <b>espelho de escrita</b> no Firestore: as leituras do
+ * fluxo REST continuam no PostgreSQL/JPA (fonte autoritativa) e a escrita é dupla
+ * (JPA + Firestore) — ver {@code DualConferenceStore}. O tipo da porta é o
+ * {@link ConferenceFirestoreDocument} (mapa próprio do domínio), nunca a entidade JPA.
+ *
+ * <p>Publica todos os dados da conferência na coleção {@code conferences}
+ * (modelagem flat, ADR-006); id do documento = {@code UUID.toString()}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.conference", havingValue = "true")
+public class ConferenceFirestoreRepository implements FirestoreRepository<ConferenceFirestoreDocument> {
+
+    public static final String COLLECTION = "conferences";
+
+    private static final long OPERATION_TIMEOUT_SECONDS = 30;
+
+    private final Firestore firestore;
+
+    @Override
+    public Optional<ConferenceFirestoreDocument> findById(String id) {
+        DocumentSnapshot snapshot = await(firestore.collection(COLLECTION).document(id).get(), "ler");
+        if (!snapshot.exists()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(ConferenceFirestoreDocument.fromMap(snapshot.getData()));
+    }
+
+    @Override
+    public List<ConferenceFirestoreDocument> findAll() {
+        QuerySnapshot snapshots = await(firestore.collection(COLLECTION).get(), "listar");
+        return snapshots.getDocuments().stream()
+                .map(DocumentSnapshot::getData)
+                .map(ConferenceFirestoreDocument::fromMap)
+                .toList();
+    }
+
+    @Override
+    public ConferenceFirestoreDocument save(ConferenceFirestoreDocument document) {
+        Objects.requireNonNull(document, "document não pode ser nulo");
+        Objects.requireNonNull(document.id(), "id do documento não pode ser nulo");
+        DocumentReference reference = firestore.collection(COLLECTION).document(document.id());
+        await(reference.set(document.toMap()), "gravar");
+        log.debug("Conference espelhada no Firestore (id={})", document.id());
+        return document;
+    }
+
+    @Override
+    public void delete(String id) {
+        await(firestore.collection(COLLECTION).document(id).delete(), "remover");
+    }
+
+    private <T> T await(ApiFuture<T> future, String operation) {
+        try {
+            return future.get(OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    "Interrompido ao " + operation + " no Firestore (coleção conferences)", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new IllegalStateException(
+                    "Falha ao " + operation + " no Firestore (coleção conferences)", e);
+        }
+    }
+}

--- a/src/main/java/br/com/flagplatform/conference/repository/ConferenceStore.java
+++ b/src/main/java/br/com/flagplatform/conference/repository/ConferenceStore.java
@@ -1,0 +1,35 @@
+package br.com.flagplatform.conference.repository;
+
+import br.com.flagplatform.conference.entity.ConferenceEntity;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Porta de persistência do domínio Conference (ADR-006). Isola o
+ * {@code ConferenceService} da tecnologia de armazenamento e viabiliza a
+ * <b>persistência dual</b>: com {@code app.firestore.conference=false} vigora a
+ * implementação JPA/PostgreSQL ({@link JpaConferenceStore}, padrão atual); com a
+ * flag {@code true} entra {@link DualConferenceStore}, que mantém o PostgreSQL
+ * como escrita autoritativa e espelha toda escrita no Firestore.
+ *
+ * <p>As leituras sempre vêm do PostgreSQL (fonte de verdade); o Firestore é o
+ * espelho/realtime para os apps. Regras de negócio e contrato REST ficam intactos
+ * no service — ele conhece apenas esta porta.
+ */
+public interface ConferenceStore {
+
+    ConferenceEntity save(ConferenceEntity entity);
+
+    Optional<ConferenceEntity> findById(UUID id);
+
+    List<ConferenceEntity> findAllByCompetitionIdOrderByNameAsc(UUID competitionId);
+
+    boolean existsByCompetitionIdAndNameIgnoreCase(UUID competitionId, String name);
+
+    boolean existsByCompetitionIdAndNameIgnoreCaseAndIdNot(UUID competitionId, String name, UUID id);
+
+    void delete(ConferenceEntity entity);
+
+}

--- a/src/main/java/br/com/flagplatform/conference/repository/DualConferenceStore.java
+++ b/src/main/java/br/com/flagplatform/conference/repository/DualConferenceStore.java
@@ -1,0 +1,72 @@
+package br.com.flagplatform.conference.repository;
+
+import br.com.flagplatform.conference.entity.ConferenceEntity;
+import br.com.flagplatform.conference.firestore.ConferenceFirestoreMapper;
+import br.com.flagplatform.conference.firestore.ConferenceFirestoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementação <b>dual</b> da porta {@link ConferenceStore} (ADR-006), vigente
+ * quando {@code app.firestore.conference=true}: escrita dupla no PostgreSQL/JPA
+ * (autoritativa) e no Firestore (espelho para os apps), leitura sempre no JPA.
+ *
+ * <p>A escrita JPA usa {@code saveAndFlush} para materializar {@code id},
+ * {@code createdAt} e {@code updatedAt} (callbacks {@code @PrePersist}/{@code @PreUpdate})
+ * antes de espelhar no Firestore — o documento espelho reflete exatamente o que o
+ * Postgres registrou. Se o Firestore falhar, a exceção propaga e a transação JPA
+ * faz rollback (persistência dual fail-fast: ou grava nas duas, ou em nenhuma).
+ * A exclusão segue o mesmo princípio: apaga no JPA e remove o espelho no Firestore.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.conference", havingValue = "true")
+public class DualConferenceStore implements ConferenceStore {
+
+    private final ConferenceRepository jpaRepository;
+    private final ConferenceFirestoreRepository firestoreRepository;
+    private final ConferenceFirestoreMapper mapper;
+
+    @Override
+    public ConferenceEntity save(ConferenceEntity entity) {
+        ConferenceEntity saved = jpaRepository.saveAndFlush(entity);
+        firestoreRepository.save(mapper.toDocument(saved));
+        log.debug("Conference persistida em dual store (id={})", saved.getId());
+        return saved;
+    }
+
+    @Override
+    public Optional<ConferenceEntity> findById(UUID id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<ConferenceEntity> findAllByCompetitionIdOrderByNameAsc(UUID competitionId) {
+        return jpaRepository.findAllByCompetitionIdOrderByNameAsc(competitionId);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndNameIgnoreCase(UUID competitionId, String name) {
+        return jpaRepository.existsByCompetitionIdAndNameIgnoreCase(competitionId, name);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndNameIgnoreCaseAndIdNot(UUID competitionId, String name, UUID id) {
+        return jpaRepository.existsByCompetitionIdAndNameIgnoreCaseAndIdNot(competitionId, name, id);
+    }
+
+    @Override
+    public void delete(ConferenceEntity entity) {
+        jpaRepository.delete(entity);
+        firestoreRepository.delete(entity.getId().toString());
+        log.debug("Conference removida do dual store (id={})", entity.getId());
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/conference/repository/JpaConferenceStore.java
+++ b/src/main/java/br/com/flagplatform/conference/repository/JpaConferenceStore.java
@@ -1,0 +1,55 @@
+package br.com.flagplatform.conference.repository;
+
+import br.com.flagplatform.conference.entity.ConferenceEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementação padrão (default) da porta {@link ConferenceStore}: delega
+ * integralmente ao repositório JPA/PostgreSQL atual. Vigora enquanto
+ * {@code app.firestore.conference} estiver {@code false} (ou ausente) — ou seja,
+ * comportamento 100% igual ao anterior à migração (ADR-006).
+ */
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.conference", havingValue = "false", matchIfMissing = true)
+public class JpaConferenceStore implements ConferenceStore {
+
+    private final ConferenceRepository repository;
+
+    @Override
+    public ConferenceEntity save(ConferenceEntity entity) {
+        return repository.save(entity);
+    }
+
+    @Override
+    public Optional<ConferenceEntity> findById(UUID id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public List<ConferenceEntity> findAllByCompetitionIdOrderByNameAsc(UUID competitionId) {
+        return repository.findAllByCompetitionIdOrderByNameAsc(competitionId);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndNameIgnoreCase(UUID competitionId, String name) {
+        return repository.existsByCompetitionIdAndNameIgnoreCase(competitionId, name);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndNameIgnoreCaseAndIdNot(UUID competitionId, String name, UUID id) {
+        return repository.existsByCompetitionIdAndNameIgnoreCaseAndIdNot(competitionId, name, id);
+    }
+
+    @Override
+    public void delete(ConferenceEntity entity) {
+        repository.delete(entity);
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/conference/service/ConferenceService.java
+++ b/src/main/java/br/com/flagplatform/conference/service/ConferenceService.java
@@ -10,8 +10,8 @@ import br.com.flagplatform.conference.entity.ConferenceEntity;
 import br.com.flagplatform.conference.exception.ConferenceNotFoundException;
 import br.com.flagplatform.conference.exception.DuplicateConferenceNameException;
 import br.com.flagplatform.conference.mapper.ConferenceMapper;
-import br.com.flagplatform.conference.repository.ConferenceRepository;
-import br.com.flagplatform.division.repository.DivisionRepository;
+import br.com.flagplatform.conference.repository.ConferenceStore;
+import br.com.flagplatform.division.repository.DivisionStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,8 +25,8 @@ import java.util.UUID;
 public class ConferenceService implements ConferenceLookup {
 
     private final ConferenceMapper mapper;
-    private final ConferenceRepository repository;
-    private final DivisionRepository divisionRepository;
+    private final ConferenceStore repository;
+    private final DivisionStore divisionStore;
     private final CompetitionLookup competitionLookup;
 
     @Transactional
@@ -82,7 +82,7 @@ public class ConferenceService implements ConferenceLookup {
         competitionLookup.assertEditable(entity.getCompetitionId());
 
         // Issue #340: remove as divisões vinculadas à conferência antes da conferência em si.
-        divisionRepository.deleteAll(divisionRepository.findAllByConferenceId(id));
+        divisionStore.deleteAll(divisionStore.findAllByConferenceId(id));
         repository.delete(entity);
     }
 

--- a/src/main/java/br/com/flagplatform/division/firestore/DivisionFirestoreBackfill.java
+++ b/src/main/java/br/com/flagplatform/division/firestore/DivisionFirestoreBackfill.java
@@ -1,0 +1,77 @@
+package br.com.flagplatform.division.firestore;
+
+import br.com.flagplatform.division.entity.DivisionEntity;
+import br.com.flagplatform.division.repository.DivisionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Backfill one-shot do domínio Division (ADR-006): copia as divisões do
+ * PostgreSQL (fonte autoritativa) para o Firestore de forma <b>idempotente</b> —
+ * seguindo o padrão de Organization (issue #7), Venue (issue #8) e Competition
+ * (issue #9). Ativado apenas quando {@code app.firestore.division=true} (perfil dev).
+ *
+ * <p>Regra por divisão (comparando o documento atual do Firestore com o esperado):
+ * <ul>
+ *   <li>documento inexistente → cria;</li>
+ *   <li>documento diferente → sobrescreve (atualiza);</li>
+ *   <li>documento idêntico → ignora (não duplica nem regrava).</li>
+ * </ul>
+ *
+ * <p>Pode rodar repetidas vezes sem efeito colateral; ao final registra a contagem
+ * {@code backfill divisions: X criadas, Y atualizadas, Z ignoradas}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.division", havingValue = "true")
+public class DivisionFirestoreBackfill implements ApplicationRunner {
+
+    private static final int PAGE_SIZE = 500;
+
+    private final DivisionRepository jpaRepository;
+    private final DivisionFirestoreRepository firestoreRepository;
+    private final DivisionFirestoreMapper mapper;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Map<String, DivisionFirestoreDocument> existing = firestoreRepository.findAll().stream()
+                .collect(Collectors.toMap(DivisionFirestoreDocument::id, document -> document));
+
+        int created = 0;
+        int updated = 0;
+        int ignored = 0;
+
+        int page = 0;
+        Page<DivisionEntity> result;
+        do {
+            result = jpaRepository.findAll(PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.ASC, "id")));
+            for (DivisionEntity entity : result.getContent()) {
+                DivisionFirestoreDocument expected = mapper.toDocument(entity);
+                DivisionFirestoreDocument current = existing.get(entity.getId().toString());
+                if (current == null) {
+                    firestoreRepository.save(expected);
+                    created++;
+                } else if (expected.equals(current)) {
+                    ignored++;
+                } else {
+                    firestoreRepository.save(expected);
+                    updated++;
+                }
+            }
+            page++;
+        } while (result.hasNext());
+
+        log.info("backfill divisions: {} criadas, {} atualizadas, {} ignoradas", created, updated, ignored);
+    }
+}

--- a/src/main/java/br/com/flagplatform/division/firestore/DivisionFirestoreDocument.java
+++ b/src/main/java/br/com/flagplatform/division/firestore/DivisionFirestoreDocument.java
@@ -1,0 +1,94 @@
+package br.com.flagplatform.division.firestore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Documento próprio do domínio Division no Firestore (ADR-006) — espelho da
+ * entidade JPA {@code DivisionEntity} em campos camelCase. NUNCA persistir a
+ * entidade JPA diretamente: o espelho usa este mapa próprio, estável para os apps
+ * (referee_app/public_app) que lerem a coleção {@code divisions} em realtime.
+ *
+ * <p>Modelagem <b>flat</b> (ADR-006): coleção própria no nível raiz, documento
+ * identificado pelo {@code UUID.toString()} da entidade e os relacionamentos
+ * expressos por campos de referência ({@code competitionId} e {@code conferenceId})
+ * — sem subcoleções aninhadas.
+ *
+ * <p>Tipos serializados (mapa simples, compatível com JSON):
+ * <ul>
+ *   <li>{@code id}/{@code competitionId}/{@code conferenceId}/{@code createdBy}/{@code updatedBy}:
+ *       UUID como {@code String};</li>
+ *   <li>{@code createdAt}/{@code updatedAt}: {@code LocalDateTime} como ISO-8601
+ *       ({@code LocalDateTime.toString()});</li>
+ *   <li>demais campos: {@code String}.</li>
+ * </ul>
+ *
+ * <p>Campos {@code null} são omitidos do documento ({@link #toMap()}) — o Firestore
+ * não armazena {@code null} e o {@code set(Map)} substitui o documento inteiro,
+ * removendo campos que deixaram de existir. A omissão consistente de {@code null}
+ * (em especial {@code conferenceId} para divisões sem conferência) também garante a
+ * idempotência do backfill ({@code expected.equals(current)}).
+ *
+ * @param id             id UUID da divisão ({@code UUID.toString()})
+ * @param competitionId  id do campeonato dono ({@code UUID.toString()})
+ * @param conferenceId   id da conferência vinculada, quando houver ({@code UUID.toString()})
+ * @param name           nome da divisão
+ * @param createdAt      data de criação (ISO-8601)
+ * @param updatedAt      data da última atualização (ISO-8601)
+ * @param createdBy      id do usuário que criou ({@code UUID.toString()})
+ * @param updatedBy      id do usuário que atualizou ({@code UUID.toString()})
+ */
+public record DivisionFirestoreDocument(
+        String id,
+        String competitionId,
+        String conferenceId,
+        String name,
+        String createdAt,
+        String updatedAt,
+        String createdBy,
+        String updatedBy
+) {
+
+    /**
+     * Converte o snapshot lido do Firestore (mapa) de volta para o documento.
+     * Campos ausentes viram {@code null}.
+     */
+    public static DivisionFirestoreDocument fromMap(Map<String, Object> data) {
+        if (data == null || data.isEmpty()) {
+            return null;
+        }
+        return new DivisionFirestoreDocument(
+                (String) data.get("id"),
+                (String) data.get("competitionId"),
+                (String) data.get("conferenceId"),
+                (String) data.get("name"),
+                (String) data.get("createdAt"),
+                (String) data.get("updatedAt"),
+                (String) data.get("createdBy"),
+                (String) data.get("updatedBy"));
+    }
+
+    /**
+     * Converte o documento para o mapa gravado no Firestore, omitindo campos
+     * {@code null} (o Firestore não armazena null e o {@code set(Map)} sobrescreve
+     * o documento inteiro, removendo campos que deixaram de existir).
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> data = new HashMap<>();
+        putIfNotNull(data, "id", id);
+        putIfNotNull(data, "competitionId", competitionId);
+        putIfNotNull(data, "conferenceId", conferenceId);
+        putIfNotNull(data, "name", name);
+        putIfNotNull(data, "createdAt", createdAt);
+        putIfNotNull(data, "updatedAt", updatedAt);
+        putIfNotNull(data, "createdBy", createdBy);
+        putIfNotNull(data, "updatedBy", updatedBy);
+        return data;
+    }
+
+    private static void putIfNotNull(Map<String, Object> data, String key, String value) {
+        if (value != null) {
+            data.put(key, value);
+        }
+    }
+}

--- a/src/main/java/br/com/flagplatform/division/firestore/DivisionFirestoreMapper.java
+++ b/src/main/java/br/com/flagplatform/division/firestore/DivisionFirestoreMapper.java
@@ -1,0 +1,40 @@
+package br.com.flagplatform.division.firestore;
+
+import br.com.flagplatform.division.entity.DivisionEntity;
+import org.mapstruct.Mapper;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Mapeia {@link DivisionEntity} (JPA) ↔ {@link DivisionFirestoreDocument}
+ * (espelho Firestore, ADR-006). Conversões próprias do domínio, em campos camelCase.
+ *
+ * <p>UUIDs e {@link LocalDateTime} viram {@code String} para manter o documento
+ * simples e JSON-friendly — ver {@link DivisionFirestoreDocument}.
+ */
+@Mapper(componentModel = "spring")
+public interface DivisionFirestoreMapper {
+
+    DivisionFirestoreDocument toDocument(DivisionEntity entity);
+
+    DivisionEntity toEntity(DivisionFirestoreDocument document);
+
+    // entity → documento
+    default String map(UUID value) {
+        return value == null ? null : value.toString();
+    }
+
+    default String map(LocalDateTime value) {
+        return value == null ? null : value.toString();
+    }
+
+    // documento → entity
+    default UUID mapUuid(String value) {
+        return value == null ? null : UUID.fromString(value);
+    }
+
+    default LocalDateTime mapLocalDateTime(String value) {
+        return value == null ? null : LocalDateTime.parse(value);
+    }
+}

--- a/src/main/java/br/com/flagplatform/division/firestore/DivisionFirestoreRepository.java
+++ b/src/main/java/br/com/flagplatform/division/firestore/DivisionFirestoreRepository.java
@@ -1,0 +1,93 @@
+package br.com.flagplatform.division.firestore;
+
+import br.com.flagplatform.common.firebase.FirestoreRepository;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.QuerySnapshot;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Implementação Firestore do domínio Division (ADR-006) — espelho de escrita da
+ * persistência dual (issue #10, seguindo o padrão de Organization/issue #7, Venue/issue #8
+ * e Competition/issue #9). Ativada apenas quando {@code app.firestore.division=true}
+ * (e, por consequência, {@code app.firestore.enabled=true} para existir o bean
+ * {@link Firestore} do {@code FirestoreFactory}).
+ *
+ * <p>Este repositório é o <b>espelho de escrita</b> no Firestore: as leituras do
+ * fluxo REST continuam no PostgreSQL/JPA (fonte autoritativa) e a escrita é dupla
+ * (JPA + Firestore) — ver {@code DualDivisionStore}. O tipo da porta é o
+ * {@link DivisionFirestoreDocument} (mapa próprio do domínio), nunca a entidade JPA.
+ *
+ * <p>Publica todos os dados da divisão na coleção {@code divisions}
+ * (modelagem flat, ADR-006); id do documento = {@code UUID.toString()}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.division", havingValue = "true")
+public class DivisionFirestoreRepository implements FirestoreRepository<DivisionFirestoreDocument> {
+
+    public static final String COLLECTION = "divisions";
+
+    private static final long OPERATION_TIMEOUT_SECONDS = 30;
+
+    private final Firestore firestore;
+
+    @Override
+    public Optional<DivisionFirestoreDocument> findById(String id) {
+        DocumentSnapshot snapshot = await(firestore.collection(COLLECTION).document(id).get(), "ler");
+        if (!snapshot.exists()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(DivisionFirestoreDocument.fromMap(snapshot.getData()));
+    }
+
+    @Override
+    public List<DivisionFirestoreDocument> findAll() {
+        QuerySnapshot snapshots = await(firestore.collection(COLLECTION).get(), "listar");
+        return snapshots.getDocuments().stream()
+                .map(DocumentSnapshot::getData)
+                .map(DivisionFirestoreDocument::fromMap)
+                .toList();
+    }
+
+    @Override
+    public DivisionFirestoreDocument save(DivisionFirestoreDocument document) {
+        Objects.requireNonNull(document, "document não pode ser nulo");
+        Objects.requireNonNull(document.id(), "id do documento não pode ser nulo");
+        DocumentReference reference = firestore.collection(COLLECTION).document(document.id());
+        await(reference.set(document.toMap()), "gravar");
+        log.debug("Division espelhada no Firestore (id={})", document.id());
+        return document;
+    }
+
+    @Override
+    public void delete(String id) {
+        await(firestore.collection(COLLECTION).document(id).delete(), "remover");
+    }
+
+    private <T> T await(ApiFuture<T> future, String operation) {
+        try {
+            return future.get(OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    "Interrompido ao " + operation + " no Firestore (coleção divisions)", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new IllegalStateException(
+                    "Falha ao " + operation + " no Firestore (coleção divisions)", e);
+        }
+    }
+}

--- a/src/main/java/br/com/flagplatform/division/repository/DivisionStore.java
+++ b/src/main/java/br/com/flagplatform/division/repository/DivisionStore.java
@@ -1,0 +1,47 @@
+package br.com.flagplatform.division.repository;
+
+import br.com.flagplatform.division.entity.DivisionEntity;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Porta de persistência do domínio Division (ADR-006). Isola o
+ * {@code DivisionService} (e o cascade de exclusão do {@code ConferenceService})
+ * da tecnologia de armazenamento e viabiliza a <b>persistência dual</b>: com
+ * {@code app.firestore.division=false} vigora a implementação JPA/PostgreSQL
+ * ({@link JpaDivisionStore}, padrão atual); com a flag {@code true} entra
+ * {@link DualDivisionStore}, que mantém o PostgreSQL como escrita autoritativa e
+ * espelha toda escrita no Firestore.
+ *
+ * <p>As leituras sempre vêm do PostgreSQL (fonte de verdade); o Firestore é o
+ * espelho/realtime para os apps. Regras de negócio e contrato REST ficam intactos
+ * no service — ele conhece apenas esta porta.
+ */
+public interface DivisionStore {
+
+    DivisionEntity save(DivisionEntity entity);
+
+    Optional<DivisionEntity> findById(UUID id);
+
+    List<DivisionEntity> findAllByCompetitionIdOrderByNameAsc(UUID competitionId);
+
+    List<DivisionEntity> findAllByConferenceId(UUID conferenceId);
+
+    boolean existsByCompetitionIdAndConferenceIdAndNameIgnoreCase(
+            UUID competitionId, UUID conferenceId, String name);
+
+    boolean existsByCompetitionIdAndConferenceIdAndNameIgnoreCaseAndIdNot(
+            UUID competitionId, UUID conferenceId, String name, UUID id);
+
+    boolean existsByCompetitionIdAndConferenceIdIsNullAndNameIgnoreCase(UUID competitionId, String name);
+
+    boolean existsByCompetitionIdAndConferenceIdIsNullAndNameIgnoreCaseAndIdNot(
+            UUID competitionId, String name, UUID id);
+
+    void delete(DivisionEntity entity);
+
+    void deleteAll(Iterable<DivisionEntity> entities);
+
+}

--- a/src/main/java/br/com/flagplatform/division/repository/DualDivisionStore.java
+++ b/src/main/java/br/com/flagplatform/division/repository/DualDivisionStore.java
@@ -1,0 +1,101 @@
+package br.com.flagplatform.division.repository;
+
+import br.com.flagplatform.division.entity.DivisionEntity;
+import br.com.flagplatform.division.firestore.DivisionFirestoreMapper;
+import br.com.flagplatform.division.firestore.DivisionFirestoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementação <b>dual</b> da porta {@link DivisionStore} (ADR-006), vigente
+ * quando {@code app.firestore.division=true}: escrita dupla no PostgreSQL/JPA
+ * (autoritativa) e no Firestore (espelho para os apps), leitura sempre no JPA.
+ *
+ * <p>A escrita JPA usa {@code saveAndFlush} para materializar {@code id},
+ * {@code createdAt} e {@code updatedAt} (callbacks {@code @PrePersist}/{@code @PreUpdate})
+ * antes de espelhar no Firestore — o documento espelho reflete exatamente o que o
+ * Postgres registrou. Se o Firestore falhar, a exceção propaga e a transação JPA
+ * faz rollback (persistência dual fail-fast: ou grava nas duas, ou em nenhuma).
+ * A exclusão segue o mesmo princípio: apaga no JPA e remove o espelho no Firestore.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.division", havingValue = "true")
+public class DualDivisionStore implements DivisionStore {
+
+    private final DivisionRepository jpaRepository;
+    private final DivisionFirestoreRepository firestoreRepository;
+    private final DivisionFirestoreMapper mapper;
+
+    @Override
+    public DivisionEntity save(DivisionEntity entity) {
+        DivisionEntity saved = jpaRepository.saveAndFlush(entity);
+        firestoreRepository.save(mapper.toDocument(saved));
+        log.debug("Division persistida em dual store (id={})", saved.getId());
+        return saved;
+    }
+
+    @Override
+    public Optional<DivisionEntity> findById(UUID id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<DivisionEntity> findAllByCompetitionIdOrderByNameAsc(UUID competitionId) {
+        return jpaRepository.findAllByCompetitionIdOrderByNameAsc(competitionId);
+    }
+
+    @Override
+    public List<DivisionEntity> findAllByConferenceId(UUID conferenceId) {
+        return jpaRepository.findAllByConferenceId(conferenceId);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndConferenceIdAndNameIgnoreCase(
+            UUID competitionId, UUID conferenceId, String name) {
+        return jpaRepository.existsByCompetitionIdAndConferenceIdAndNameIgnoreCase(competitionId, conferenceId, name);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndConferenceIdAndNameIgnoreCaseAndIdNot(
+            UUID competitionId, UUID conferenceId, String name, UUID id) {
+        return jpaRepository.existsByCompetitionIdAndConferenceIdAndNameIgnoreCaseAndIdNot(
+                competitionId, conferenceId, name, id);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndConferenceIdIsNullAndNameIgnoreCase(UUID competitionId, String name) {
+        return jpaRepository.existsByCompetitionIdAndConferenceIdIsNullAndNameIgnoreCase(competitionId, name);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndConferenceIdIsNullAndNameIgnoreCaseAndIdNot(
+            UUID competitionId, String name, UUID id) {
+        return jpaRepository.existsByCompetitionIdAndConferenceIdIsNullAndNameIgnoreCaseAndIdNot(
+                competitionId, name, id);
+    }
+
+    @Override
+    public void delete(DivisionEntity entity) {
+        jpaRepository.delete(entity);
+        firestoreRepository.delete(entity.getId().toString());
+        log.debug("Division removida do dual store (id={})", entity.getId());
+    }
+
+    @Override
+    public void deleteAll(Iterable<DivisionEntity> entities) {
+        jpaRepository.deleteAll(entities);
+        for (DivisionEntity entity : entities) {
+            firestoreRepository.delete(entity.getId().toString());
+        }
+        log.debug("Division(s) removida(s) do dual store");
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/division/repository/JpaDivisionStore.java
+++ b/src/main/java/br/com/flagplatform/division/repository/JpaDivisionStore.java
@@ -1,0 +1,80 @@
+package br.com.flagplatform.division.repository;
+
+import br.com.flagplatform.division.entity.DivisionEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Implementação padrão (default) da porta {@link DivisionStore}: delega
+ * integralmente ao repositório JPA/PostgreSQL atual. Vigora enquanto
+ * {@code app.firestore.division} estiver {@code false} (ou ausente) — ou seja,
+ * comportamento 100% igual ao anterior à migração (ADR-006).
+ */
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.firestore.division", havingValue = "false", matchIfMissing = true)
+public class JpaDivisionStore implements DivisionStore {
+
+    private final DivisionRepository repository;
+
+    @Override
+    public DivisionEntity save(DivisionEntity entity) {
+        return repository.save(entity);
+    }
+
+    @Override
+    public Optional<DivisionEntity> findById(UUID id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public List<DivisionEntity> findAllByCompetitionIdOrderByNameAsc(UUID competitionId) {
+        return repository.findAllByCompetitionIdOrderByNameAsc(competitionId);
+    }
+
+    @Override
+    public List<DivisionEntity> findAllByConferenceId(UUID conferenceId) {
+        return repository.findAllByConferenceId(conferenceId);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndConferenceIdAndNameIgnoreCase(
+            UUID competitionId, UUID conferenceId, String name) {
+        return repository.existsByCompetitionIdAndConferenceIdAndNameIgnoreCase(competitionId, conferenceId, name);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndConferenceIdAndNameIgnoreCaseAndIdNot(
+            UUID competitionId, UUID conferenceId, String name, UUID id) {
+        return repository.existsByCompetitionIdAndConferenceIdAndNameIgnoreCaseAndIdNot(
+                competitionId, conferenceId, name, id);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndConferenceIdIsNullAndNameIgnoreCase(UUID competitionId, String name) {
+        return repository.existsByCompetitionIdAndConferenceIdIsNullAndNameIgnoreCase(competitionId, name);
+    }
+
+    @Override
+    public boolean existsByCompetitionIdAndConferenceIdIsNullAndNameIgnoreCaseAndIdNot(
+            UUID competitionId, String name, UUID id) {
+        return repository.existsByCompetitionIdAndConferenceIdIsNullAndNameIgnoreCaseAndIdNot(
+                competitionId, name, id);
+    }
+
+    @Override
+    public void delete(DivisionEntity entity) {
+        repository.delete(entity);
+    }
+
+    @Override
+    public void deleteAll(Iterable<DivisionEntity> entities) {
+        repository.deleteAll(entities);
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/division/service/DivisionService.java
+++ b/src/main/java/br/com/flagplatform/division/service/DivisionService.java
@@ -12,7 +12,7 @@ import br.com.flagplatform.division.exception.ConferenceCompetitionMismatchExcep
 import br.com.flagplatform.division.exception.DivisionNotFoundException;
 import br.com.flagplatform.division.exception.DuplicateDivisionNameException;
 import br.com.flagplatform.division.mapper.DivisionMapper;
-import br.com.flagplatform.division.repository.DivisionRepository;
+import br.com.flagplatform.division.repository.DivisionStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +26,7 @@ import java.util.UUID;
 public class DivisionService implements DivisionLookup {
 
     private final DivisionMapper mapper;
-    private final DivisionRepository repository;
+    private final DivisionStore repository;
     private final CompetitionLookup competitionLookup;
     private final ConferenceLookup conferenceLookup;
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -29,6 +29,12 @@ app:
     # Issue #9: campeonatos espelham no Firestore (persistência dual) quando true —
     # default ON no perfil dev.
     competition: ${FIRESTORE_COMPETITION_ENABLED:true}
+    # Issue #10: conferências espelham no Firestore (persistência dual) quando true —
+    # default ON no perfil dev.
+    conference: ${FIRESTORE_CONFERENCE_ENABLED:true}
+    # Issue #10: divisões espelham no Firestore (persistência dual) quando true —
+    # default ON no perfil dev.
+    division: ${FIRESTORE_DIVISION_ENABLED:true}
 
 logging:
   level:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,6 +24,10 @@ app:
     venue: ${FIRESTORE_VENUE_ENABLED:false}
     # Domínio competition também OFF no perfil local (padrão = sem espelho).
     competition: ${FIRESTORE_COMPETITION_ENABLED:false}
+    # Domínio conference também OFF no perfil local (padrão = sem espelho).
+    conference: ${FIRESTORE_CONFERENCE_ENABLED:false}
+    # Domínio division também OFF no perfil local (padrão = sem espelho).
+    division: ${FIRESTORE_DIVISION_ENABLED:false}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,6 +92,10 @@ app:
     venue: ${FIRESTORE_VENUE_ENABLED:false}
     # Issue #9: campeonatos espelham no Firestore quando true.
     competition: ${FIRESTORE_COMPETITION_ENABLED:false}
+    # Issue #10: conferências espelham no Firestore quando true.
+    conference: ${FIRESTORE_CONFERENCE_ENABLED:false}
+    # Issue #10: divisões espelham no Firestore quando true.
+    division: ${FIRESTORE_DIVISION_ENABLED:false}
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## Contexto

Continuação da persistência dual (ADR-006) no padrão já consolidado em `organization`, `venue` e `competition` (#9). H6: **Conferências e Divisões** passam a espelhar no Firestore — somente para consumo dos apps (espelho de escrita); a fonte de verdade continua o Postgres/JPA e as leituras do backend permanecem no JPA.

## Mudanças

Criados (padrão dual completo por domínio):

- **Conference** (`conference/repository/`): `ConferenceStore` (porta), `JpaConferenceStore` (default), `DualConferenceStore` (dual fail-fast, write-through JPA+Firestore com rollback em falha)
- **Conference** (`conference/firestore/`): `ConferenceFirestoreDocument`, `ConferenceFirestoreMapper`, `ConferenceFirestoreRepository` (coleção `conferences`), `ConferenceFirestoreBackfill` (idempotente)
- **Division** (`division/repository/` + `division/firestore/`): mesma estrutura (coleção `divisions`), porta inclui as assinaturas usadas pelo cascade do `ConferenceService` (`findAllByConferenceId`, `delete`, `deleteAll` etc.)
- `ConferenceService`/`DivisionService` agora injetam as portas em vez do JPA direto — contrato REST intacto
- Flags: `app.firestore.conference` / `app.firestore.division` — **dev `true`**, local/base `false` (padrão #9)
- **ADR-006**: nova seção documentando a modelagem **flat** (coleções próprias com campos de referência `competitionId`/`conferenceId`) em vez de aninhada sob `competitions/{id}/...` — justificativa: uniformidade com org/venue/competition, documento id = UUID da entidade, escritas individuais sem re-gravação de subárvores, queries simples e regras de segurança fáceis de auditar

## Validação

- `.\mvnw.cmd clean compile` → BUILD SUCCESS (330 fontes, EXIT 0)

Closes #10