### PR TITLE
chore(#28): perfil dev usa Firestore real (sem emulador)

### DIFF
--- a/src/main/java/br/com/flagplatform/common/firebase/FirestoreFactory.java
+++ b/src/main/java/br/com/flagplatform/common/firebase/FirestoreFactory.java
@@ -30,10 +30,14 @@ import java.nio.file.Path;
  *
  * <h2>Configuração por ambiente</h2>
  * <ul>
- *   <li><b>Emulador local (perfil {@code dev})</b>: ativado quando o host do emulador é
- *       resolvido. Resolução em ordem: propriedade {@code app.firestore.emulator-host}
- *       (application-dev.yml → {@code ${FIRESTORE_EMULATOR_HOST:localhost:9090}}) e depois
- *       a env var {@code FIRESTORE_EMULATOR_HOST}. Neste modo as credenciais são fictícias
+ *   <li><b>Perfil {@code dev} — Firestore real (default)</b>: sem host de emulador, conecta no
+ *       Cloud Firestore do projeto {@code flag-platform} (default database {@code (default)}).
+ *       Credenciais exigidas: {@code FIREBASE_SERVICE_ACCOUNT} (caminho do JSON),
+ *       {@code GOOGLE_APPLICATION_CREDENTIALS} ou Application Default Credentials.
+ *       Emulador é opcional: exporte {@code FIRESTORE_EMULATOR_HOST} (ex. {@code localhost:9090})
+ *       antes de subir — application-dev.yml repassa a env via
+ *       {@code app.firestore.emulator-host} ({@code ${FIRESTORE_EMULATOR_HOST:}}), e a resolução
+ *       continua na ordem propriedade → env var. Neste modo as credenciais são fictícias
  *       ({@link EmulatorCredentials}) e o host é passado via
  *       {@link FirestoreOptions.Builder#setEmulatorHost(String)}.</li>
  *   <li><b>API real do Firebase (prod)</b>: sem host de emulador. Credenciais vindas de

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,11 +15,12 @@ spring:
 
 app:
   firestore:
-    # Perfil dev usa o EMULADOR local do Firestore (default ON).
-    # Porta 9090 por padrão para não conflitar com o backend (8080).
-    # Para usar outra porta, exporte FIRESTORE_EMULATOR_HOST antes de subir.
+    # Perfil dev usa o FIRESTORE REAL do projeto flag-platform (default database "(default)").
+    # Sem FIRESTORE_EMULATOR_HOST, o FirestoreFactory resolve credenciais via
+    # FIREBASE_SERVICE_ACCOUNT (caminho do JSON), GOOGLE_APPLICATION_CREDENTIALS ou ADC.
+    # Emulador é OPCIONAL: exporte FIRESTORE_EMULATOR_HOST (ex.: localhost:9090) antes de subir.
     enabled: ${FIRESTORE_ENABLED:true}
-    emulator-host: ${FIRESTORE_EMULATOR_HOST:localhost:9090}
+    emulator-host: ${FIRESTORE_EMULATOR_HOST:}
     # Domínio piloto do ADR-006 (issue #7): organizações espelham no Firestore
     # (persistência dual) quando a flag está true — default ON no perfil dev.
     organization: ${FIRESTORE_ORGANIZATION_ENABLED:true}


### PR DESCRIPTION
## Contexto

**Issue #28:** o projeto `flag-platform` tem o **default database do Firestore real**, e o ambiente dev passa a usá-lo **sem emulador** (decisão 2026-09-05; emulador descartado).

O `FirestoreFactory` já conecta no Cloud real quando não há `emulator-host` — esta mudança apenas remove o default do emulador no perfil dev, mantendo escape opcional via env.

## Mudanças

1. **`application-dev.yml`**: `emulator-host` passa de `localhost:9090` (default) para `${FIRESTORE_EMULATOR_HOST:}` — vazio = Firestore real por padrão; se a env for setada, volta ao emulador. Comentário do bloco atualizado.
2. **`FirestoreFactory.java`** (javadoc): registra que o perfil dev conecta no Firestore real do projeto `flag-platform` (default database `(default)`), credenciais via `FIREBASE_SERVICE_ACCOUNT` / `GOOGLE_APPLICATION_CREDENTIALS` / ADC, e emulador apenas opcional via `FIRESTORE_EMULATOR_HOST`.

## Não escopo (mantido)
- Lógica de negócio, contratos REST, Flyway, regras de segurança Firestore (deploy de rules será à parte via firebase CLI).

## Pontos de atenção
- **Validação funcional pendente**: exige a chave do service account (`C:\Projetos\America\firebase-service-account.json`) a ser baixada pelo usuário no Console do `flag-platform` — fora do repositório. O código já resolve automaticamente assim que a env `FIREBASE_SERVICE_ACCOUNT` apontar para a chave.
- Item 3 da issue (README) é **N/A**: não existe README nem seção de emulador/dev no backend.

## Validação
- `.\mvnw.cmd clean compile` → **EXIT 0**.

Closes #28