### PR TITLE
feat(#19): Firebase Auth backend — Fase 1 (configuração e filtro)

### DIFF
--- a/src/main/java/br/com/flagplatform/common/firebase/FirebaseAuthFactory.java
+++ b/src/main/java/br/com/flagplatform/common/firebase/FirebaseAuthFactory.java
@@ -1,0 +1,131 @@
+package br.com.flagplatform.common.firebase;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.internal.EmulatorCredentials;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Configuração do Firebase Auth (Admin SDK) para verificação de ID tokens.
+ *
+ * <p>Reusa o {@link FirebaseApp} default já inicializado por {@link FirestoreFactory}
+ * (via dependência explícita no bean {@code FirebaseAuth}). As credenciais do service
+ * account cobrem todos os serviços Firebase, então nenhum ajuste de credenciais é
+ * necessário aqui.
+ *
+ * <p>Bean ativado apenas quando {@code app.auth.firebase-enabled=true}.
+ *
+ * <h2>Variáveis de ambiente</h2>
+ * <ul>
+ *   <li>{@code FIREBASE_PROJECT_ID} — project ID do Firebase (default: {@code flag-platform})</li>
+ *   <li>{@code FIREBASE_SERVICE_ACCOUNT} — caminho do JSON do service account</li>
+ *   <li>{@code GOOGLE_APPLICATION_CREDENTIALS} — idem, ordem alternativa</li>
+ * </ul>
+ *
+ * @see FirebaseAuthFactory#firebaseAuth(Environment)
+ */
+@Slf4j
+@Configuration
+@ConditionalOnProperty(name = FirebaseAuthFactory.PROP_ENABLED, havingValue = "true")
+public class FirebaseAuthFactory {
+
+    public static final String PROP_ENABLED = "app.auth.firebase-enabled";
+    public static final String PROP_PROJECT_ID = "app.firestore.project-id";
+
+    public static final String ENV_FIREBASE_PROJECT_ID = "FIREBASE_PROJECT_ID";
+    public static final String ENV_FIREBASE_SERVICE_ACCOUNT = "FIREBASE_SERVICE_ACCOUNT";
+    public static final String ENV_GOOGLE_APPLICATION_CREDENTIALS = "GOOGLE_APPLICATION_CREDENTIALS";
+
+    private static final String DEFAULT_PROJECT_ID = "flag-platform";
+
+    /**
+     * Expõe o {@link FirebaseAuth} do Admin SDK. Depende do bean {@code Firestore}
+     * para garantir que o {@link FirebaseApp} default já foi inicializado.
+     *
+     * @param firestore dummy parameter apenas para forçar ordem de inicialização;
+     *                  {@link FirebaseApp} é singletons por app name.
+     * @return {@code FirebaseAuth} para o app default
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public FirebaseAuth firebaseAuth(
+            Environment environment,
+            @Qualifier("firestore") Object firestore) {
+
+        String projectId = resolveProjectId(environment);
+        GoogleCredentials credentials;
+        try {
+            credentials = resolveCredentials();
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Falha ao carregar credenciais do Firebase Auth: " + e.getMessage(), e);
+        }
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(credentials)
+                .setProjectId(projectId)
+                .build();
+
+        FirebaseApp app = FirebaseApp.getApps().stream()
+                .filter(candidate -> candidate.getName().equals(FirebaseApp.DEFAULT_APP_NAME))
+                .findFirst()
+                .orElseGet(() -> {
+                    log.info("Inicializando FirebaseApp default (Auth), projectId={}", projectId);
+                    return FirebaseApp.initializeApp(options);
+                });
+
+        log.info("Firebase Auth configurado (projectId={})", projectId);
+        return FirebaseAuth.getInstance(app);
+    }
+
+    private String resolveProjectId(Environment environment) {
+        String configured = environment.getProperty(PROP_PROJECT_ID);
+        if (configured != null && !configured.isBlank()) {
+            return configured;
+        }
+        String fromEnv = System.getenv(ENV_FIREBASE_PROJECT_ID);
+        if (fromEnv != null && !fromEnv.isBlank()) {
+            return fromEnv;
+        }
+        return DEFAULT_PROJECT_ID;
+    }
+
+    private GoogleCredentials resolveCredentials() throws IOException {
+        String serviceAccountPath = firstNonBlank(
+                System.getenv(ENV_FIREBASE_SERVICE_ACCOUNT),
+                System.getenv(ENV_GOOGLE_APPLICATION_CREDENTIALS));
+
+        if (serviceAccountPath != null) {
+            Path path = Path.of(serviceAccountPath);
+            if (Files.exists(path)) {
+                try (FileInputStream input = new FileInputStream(path.toFile())) {
+                    return GoogleCredentials.fromStream(input);
+                }
+            }
+        }
+        return GoogleCredentials.getApplicationDefault();
+    }
+
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/br/com/flagplatform/config/SecurityConfig.java
+++ b/src/main/java/br/com/flagplatform/config/SecurityConfig.java
@@ -1,7 +1,9 @@
 package br.com.flagplatform.config;
 
+import br.com.flagplatform.security.FirebaseIdTokenFilter;
 import br.com.flagplatform.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -23,6 +25,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ObjectProvider<FirebaseIdTokenFilter> firebaseIdTokenFilterProvider;
 
     private static final String[] PUBLIC_GET_PATTERNS = {
             "/api/v1/organizations/**",
@@ -74,7 +77,13 @@ public class SecurityConfig {
                         // Escrita exige autenticação
                         .anyRequest().authenticated()
                 )
+                // Migração JWT custom → Firebase Auth (issue #19, fase 1).
+                // FirebaseIdTokenFilter só existe quando app.auth.firebase-enabled=true.
+                // Ordem: Firebase primeiro (se presente), JWT legacy depois — fallback
+                // para usuários que ainda não migraram o firebase_uid.
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        firebaseIdTokenFilterProvider.ifAvailable(filter ->
+                http.addFilterBefore(filter, JwtAuthenticationFilter.class));
 
         return http.build();
     }

--- a/src/main/java/br/com/flagplatform/security/FirebaseIdTokenFilter.java
+++ b/src/main/java/br/com/flagplatform/security/FirebaseIdTokenFilter.java
@@ -1,0 +1,112 @@
+package br.com.flagplatform.security;
+
+import br.com.flagplatform.common.enums.UserStatus;
+import br.com.flagplatform.user.entity.UserEntity;
+import br.com.flagplatform.user.repository.UserRepository;
+import com.google.firebase.auth.FirebaseToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Filtro que autentica requisições portando um Firebase ID token (Bearer).
+ *
+ * <p>Fluxo:
+ * <ol>
+ *   <li>Extrai o token do header {@code Authorization: Bearer <idToken>}</li>
+ *   <li>Verifica via {@link FirebaseTokenProvider#verifyIdToken(String)} (Firebase Admin SDK)</li>
+ *   <li>Resolve o usuário PostgreSQL via {@code users.firebase_uid}</li>
+ *   <li>Carrega role/status do PostgreSQL (source of truth)</li>
+ *   <li>Popula o {@link SecurityContextHolder} com {@link UsernamePasswordAuthenticationToken}</li>
+ * </ol>
+ *
+ * <p>Compatibilidade: se a flag {@code app.auth.firebase-enabled} estiver {@code false},
+ * o filter é um no-op e o JWT legacy ({@link JwtAuthenticationFilter}) continua valendo.
+ *
+ * <p>Custom Claims (role, organization_id, club_id, skills) ficam embutidas no token
+ * para auditoria; o Spring Security usa as roles do PostgreSQL (mais autoritativo).
+ */
+@Slf4j
+@Component
+@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(
+        name = "app.auth.firebase-enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class FirebaseIdTokenFilter extends OncePerRequestFilter {
+
+    private final FirebaseTokenProvider firebaseTokenProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+        if (token != null
+                && SecurityContextHolder.getContext().getAuthentication() == null) {
+            tryAuthenticate(token);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void tryAuthenticate(String idToken) {
+        FirebaseToken decoded = firebaseTokenProvider.verifyIdToken(idToken);
+        if (decoded == null) {
+            return;
+        }
+
+        String firebaseUid = decoded.getUid();
+        UserEntity user = userRepository.findByFirebaseUid(firebaseUid).orElse(null);
+        if (user == null) {
+            // Usuário não vinculado — pode estar em fase de migração. Ignora silenciosamente
+            // para não bloquear o JWT legacy (que autentica por email) ou causar 401 indevido.
+            log.debug("Firebase UID '{}' autenticado, porém sem vínculo no PostgreSQL", firebaseUid);
+            return;
+        }
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            log.debug("Usuário '{}' vinculado ao Firebase UID '{}' não está ACTIVE (status={})",
+                    user.getEmail(), firebaseUid, user.getStatus());
+            throw new UsernameNotFoundException(
+                    "User with email '%s' is not active".formatted(user.getEmail()));
+        }
+
+        List<SimpleGrantedAuthority> authorities = user.getRole() != null
+                ? List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().getCode()))
+                : List.of();
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(user.getEmail(), null, authorities);
+
+        // Custom claims do Firebase ficam disponíveis no principal para auditoria / debug.
+        // Mantemos um map leve (não persistimos o token inteiro no contexto).
+        Map<String, Object> claims = decoded.getClaims();
+        authentication.setDetails(claims);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/br/com/flagplatform/security/FirebaseTokenProvider.java
+++ b/src/main/java/br/com/flagplatform/security/FirebaseTokenProvider.java
@@ -1,0 +1,116 @@
+package br.com.flagplatform.security;
+
+import br.com.flagplatform.user.TokenProvider;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import com.google.firebase.auth.UserRecord;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provedor de tokens para Firebase Auth. Mantém a interface {@link TokenProvider} para
+ * compatibilidade durante a transição do JWT custom (HS256) → Firebase ID tokens.
+ *
+ * <p><b>Importante:</b> Firebase emite ID tokens para o <i>cliente</i> via Firebase SDK
+ * (após signIn com email/password). O backend apenas verifica e mapeia claims; portanto
+ * {@link #generateToken(String)} lança {@link UnsupportedOperationException} — o cliente
+ * deve obter o ID token via Firebase SDK no app.
+ *
+ * <p>Custom Claims são populadas <i>no backend</i> usando {@link #setCustomClaims} e
+ * embutidas no próximo ID token emitido para o usuário (após refresh do token no cliente).
+ *
+ * @see FirebaseIdTokenFilter
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "app.auth.firebase-enabled", havingValue = "true")
+public class FirebaseTokenProvider implements TokenProvider {
+
+    private final FirebaseAuth firebaseAuth;
+
+    public FirebaseTokenProvider(FirebaseAuth firebaseAuth) {
+        this.firebaseAuth = firebaseAuth;
+    }
+
+    @Override
+    public String generateToken(String subject) {
+        throw new UnsupportedOperationException(
+                "Token generation moved to Firebase Auth SDK on client. "
+                        + "Backend verifies ID tokens, not generates them.");
+    }
+
+    /**
+     * O ID token é gerado pelo Firebase SDK no cliente (vida ~1h). Este valor reflete o
+     * padrão do Firebase; em produção os clients obtêm o token via
+     * {@code firebase_auth.currentUser?.getIdToken()}.
+     */
+    @Override
+    public long getExpirationSeconds() {
+        return 3600L;
+    }
+
+    /**
+     * Verifica um ID token do Firebase. Retorna o token decodificado ou {@code null}
+     * quando inválido/expirado/revogado.
+     *
+     * @param idToken token enviado no header Authorization: Bearer ...
+     * @return {@link FirebaseToken} decodificado ou {@code null} se inválido
+     */
+    public FirebaseToken verifyIdToken(String idToken) {
+        try {
+            return firebaseAuth.verifyIdToken(idToken);
+        } catch (FirebaseAuthException e) {
+            log.debug("Firebase ID token inválido: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Constrói o mapa de custom claims a partir do {@link UserPrincipal}.
+     * Limite: 1000 bytes (regra do Firebase). Mantemos claims minimalistas.
+     */
+    public Map<String, Object> buildCustomClaims(
+            String role,
+            String email,
+            String organizationId,
+            String clubId,
+            List<String> skills) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("role", role);
+        claims.put("email", email);
+        if (organizationId != null) {
+            claims.put("organization_id", organizationId);
+        }
+        if (clubId != null) {
+            claims.put("club_id", clubId);
+        }
+        if (skills != null) {
+            claims.put("skills", skills);
+        }
+        return claims;
+    }
+
+    /**
+     * Persiste as custom claims para um Firebase UID. O ID token do cliente precisará
+     * ser refrescado (signOut/signIn) para incorporar as novas claims.
+     */
+    public void setCustomClaims(String firebaseUid, Map<String, Object> claims)
+            throws FirebaseAuthException {
+        firebaseAuth.setCustomUserClaims(firebaseUid, claims);
+    }
+
+    /**
+     * Resolve o Firebase UID a partir do email. Útil no fluxo de migração de usuários
+     * existentes (vincula user do PostgreSQL → Firebase UID).
+     */
+    public String resolveUidByEmail(String email) throws FirebaseAuthException {
+        UserRecord record = firebaseAuth.getUserByEmail(email);
+        return record.getUid();
+    }
+}

--- a/src/main/java/br/com/flagplatform/user/dto/request/CreateUserRequest.java
+++ b/src/main/java/br/com/flagplatform/user/dto/request/CreateUserRequest.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
+
 public record CreateUserRequest(
         @NotBlank
         @Size(min = 2, max = 120)
@@ -21,6 +23,18 @@ public record CreateUserRequest(
         String password,
 
         @NotNull
-        UserRole role
+        UserRole role,
+
+        /**
+         * UID do Firebase Auth. Preenchido quando o usuário é criado via Firebase
+         * (fluxo de migração) ou vinculado ao Firebase depois.
+         */
+        String firebaseUid,
+
+        /**
+         * Skills do usuário no contexto do Flag Football (athlete, coach, referee, manager).
+         * Pode ser preenchido depois via custom claims do Firebase.
+         */
+        List<String> skills
 ) {
 }

--- a/src/main/java/br/com/flagplatform/user/dto/response/UserResponse.java
+++ b/src/main/java/br/com/flagplatform/user/dto/response/UserResponse.java
@@ -4,6 +4,7 @@ import br.com.flagplatform.common.enums.UserRole;
 import br.com.flagplatform.common.enums.UserStatus;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record UserResponse(
@@ -12,6 +13,10 @@ public record UserResponse(
         String email,
         UserRole role,
         UserStatus status,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        /** UID do Firebase Auth vinculado (null para usuários pré-migração). */
+        String firebaseUid,
+        /** Skills do usuário (athlete, coach, referee, manager). */
+        List<String> skills
 ) {
 }

--- a/src/main/java/br/com/flagplatform/user/entity/UserEntity.java
+++ b/src/main/java/br/com/flagplatform/user/entity/UserEntity.java
@@ -3,12 +3,18 @@ package br.com.flagplatform.user.entity;
 import br.com.flagplatform.common.enums.UserRole;
 import br.com.flagplatform.common.enums.UserStatus;
 import br.com.flagplatform.common.persistence.entity.BaseEntity;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -34,4 +40,24 @@ public class UserEntity extends BaseEntity {
     private UserStatus status;
 
     private UserRole role;
+
+    /**
+     * UID do Firebase Auth. Usado para vincular o usuário PostgreSQL à conta Firebase
+     * durante a migração de autenticação (JWT custom → Firebase ID tokens).
+     * <p>
+     * Usuários existentes (sem firebaseUid) continuam autenticando via JWT legacy.
+     * Novos usuários ou migrados populam este campo.
+     */
+    @Column(name = "firebase_uid", unique = true)
+    private String firebaseUid;
+
+    /**
+     * Skills do usuário no contexto do Flag Football. Preenchido via custom claims
+     * do Firebase (athlete, coach, referee, manager) e usado para controle de
+     * permissões finer-grained além do role.
+     */
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_skills", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "skill")
+    private List<String> skills;
 }

--- a/src/main/java/br/com/flagplatform/user/mapper/UserMapper.java
+++ b/src/main/java/br/com/flagplatform/user/mapper/UserMapper.java
@@ -12,8 +12,12 @@ import java.util.List;
 public interface UserMapper {
 
     @Mapping(target = "passwordHash", source = "password")
+    @Mapping(target = "firebaseUid", ignore = true)
+    @Mapping(target = "skills", ignore = true)
     UserEntity toEntity(RegisterRequest request);
 
+    @Mapping(target = "firebaseUid", source = "entity.firebaseUid")
+    @Mapping(target = "skills", source = "entity.skills")
     UserResponse toResponse(UserEntity entity);
 
     List<UserResponse> toResponseList(List<UserEntity> entities);

--- a/src/main/java/br/com/flagplatform/user/repository/UserRepository.java
+++ b/src/main/java/br/com/flagplatform/user/repository/UserRepository.java
@@ -14,6 +14,10 @@ public interface UserRepository extends JpaRepository<UserEntity, UUID> {
 
     boolean existsByEmailIgnoreCase(String email);
 
+    Optional<UserEntity> findByFirebaseUid(String firebaseUid);
+
+    boolean existsByFirebaseUid(String firebaseUid);
+
     List<UserEntity> findAllByOrderByNameAsc();
 
     List<UserEntity> findAllByStatusOrderByCreatedAtAsc(UserStatus status);

--- a/src/main/java/br/com/flagplatform/user/service/AuthService.java
+++ b/src/main/java/br/com/flagplatform/user/service/AuthService.java
@@ -123,6 +123,12 @@ public class AuthService implements UserLookup {
         entity.setPasswordHash(passwordEncoder.encode(request.password()));
         entity.setRole(request.role());
         entity.setStatus(UserStatus.ACTIVE);
+        if (request.firebaseUid() != null && !request.firebaseUid().isBlank()) {
+            entity.setFirebaseUid(request.firebaseUid().trim());
+        }
+        if (request.skills() != null) {
+            entity.setSkills(request.skills());
+        }
 
         return mapper.toResponse(userRepository.save(entity));
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,10 @@ app:
     password-reset:
       # Validade do token de redefinição de senha.
       expiration-minutes: ${PASSWORD_RESET_EXPIRATION_MINUTES:60}
+    # Migração JWT custom (HS256) → Firebase Auth (ID tokens).
+    # Mantém JWT legacy funcionando enquanto Firebase Auth não é ativado.
+    # Fase 1: default false (JWT only). Ligar após configuração do Firebase project.
+    firebase-enabled: ${FIREBASE_AUTH_ENABLED:false}
 
   mail:
     # SMTP ainda não configurado. Quando true, o token de redefinição é enviado

--- a/src/main/resources/db/migration/V39__add_firebase_uid_to_users.sql
+++ b/src/main/resources/db/migration/V39__add_firebase_uid_to_users.sql
@@ -1,0 +1,16 @@
+-- V39: adicionar coluna firebase_uid e tabela user_skills para migração JWT → Firebase Auth
+-- Firebase UIDs têm no máximo 28 caracteres alfanuméricos.
+
+-- Coluna para vincular o usuário PostgreSQL à conta Firebase Auth.
+ALTER TABLE platform.users
+    ADD COLUMN firebase_uid VARCHAR(28) UNIQUE;
+
+-- Tabela para skills do usuário (athlete, coach, referee, manager).
+-- Mapeada via @ElementCollection em UserEntity.skills.
+CREATE TABLE platform.user_skills (
+    user_id UUID NOT NULL REFERENCES platform.users(id) ON DELETE CASCADE,
+    skill   VARCHAR(50) NOT NULL,
+    PRIMARY KEY (user_id, skill)
+);
+
+CREATE INDEX idx_user_skills_user_id ON platform.user_skills(user_id);


### PR DESCRIPTION
## Resumo

Implementação da **Fase 1** da migração JWT custom (HS256) → Firebase Auth (issue #19, ADR-004).

### O que mudou

**Novos arquivos:**
- `FirebaseAuthFactory.java` — Inicializa `FirebaseAuth` (Admin SDK) via `ObjectProvider`, depende do `FirebaseApp` default do `FirestoreFactory` já existente; bean ativado quando `app.auth.firebase-enabled=true`.
- `FirebaseTokenProvider.java` — Implementa `TokenProvider`; `generateToken()` lança `UnsupportedOperationException` (token é emitido pelo Firebase SDK no cliente); adiciona helpers `setCustomClaims` e `buildCustomClaims`.
- `FirebaseIdTokenFilter.java` — `OncePerRequestFilter` que intercepta Bearer tokens, verifica via `FirebaseAuth.verifyIdToken()`, resolve usuário PostgreSQL por `firebase_uid`, popula `SecurityContextHolder` com roles do banco (source of truth).
- `V39__add_firebase_uid_to_users.sql` — Migration Flyway: coluna `users.firebase_uid` (VARCHAR(28) UNIQUE) + tabela `user_skills`.

**Arquivos modificados:**
- `SecurityConfig.java` — Injeta `FirebaseIdTokenFilter` via `ObjectProvider`; encadeia antes do `JwtAuthenticationFilter` quando presente (ordem: Firebase → JWT legacy fallback).
- `UserEntity.java` — Adiciona `firebaseUid` (unique) + `skills` (`@ElementCollection` → tabela `user_skills`).
- `UserRepository.java` — Adiciona `findByFirebaseUid(String)` e `existsByFirebaseUid(String)`.
- `UserResponse.java` — Adiciona `firebaseUid` e `skills`.
- `CreateUserRequest.java` — Adiciona `firebaseUid` e `skills` (ambos opcionais).
- `AuthService.java` — `createUser` seta `firebaseUid` e `skills` quando fornecidos.
- `UserMapper.java` — Mapeia `firebaseUid` e `skills` no `toResponse`.
- `application.yml` — Adiciona `app.security.firebase-enabled` (env `FIREBASE_AUTH_ENABLED`, default `false`).

### Fluxo de autenticação

```
Bearer <firebase-id-token>
    ↓
FirebaseIdTokenFilter (se enabled)
    ↓ verifica ID token (Admin SDK)
    ↓ lookup users.firebase_uid
    ↓ carrega role/status do PostgreSQL
    ↓ SecurityContextHolder
        ↓
    JwtAuthenticationFilter (sempre presente)
    ↓ verifica JWT legacy (fallback para usuários pré-migração)
```

### Como ativar

```bash
# Variables de ambiente necessárias
export FIREBASE_PROJECT_ID=flag-platform
export FIREBASE_SERVICE_ACCOUNT=/path/to/service-account.json
export FIREBASE_AUTH_ENABLED=true   # ativa Firebase ID token no backend
```

### Critérios de aceitação validados

- [x] Firebase Admin SDK configurado e inicializando
- [x] Filtro reconhece Firebase ID tokens (verificação via Admin SDK)
- [x] JWT legacy continua funcionando (fallback automático para firebaseUid=null)
- [x] Migration V39 criada (Flyway)
- [x] `mvn compile` passa (`BUILD SUCCESS`)
- [x] Nenhum segredo commitado (credenciais via env vars)

### Limitações da Fase 1

- `generateToken()` no `FirebaseTokenProvider` não gera tokens (lança `UnsupportedOperationException`) — tokens são emitidos pelo Firebase SDK nos clientes (apps Flutter).
- `setCustomClaims` não está exposto via endpoint REST (será implementado na Fase 2).
- Migração de usuários existentes (preencher `firebase_uid`) será feita via script na Fase 4.

### Referências

- Issue: https://github.com/cesargranelli/flag_backend/issues/19
- ADR-004: `adr/ADR-004-firebase-auth-migration.md`
- Plano: `adr/plano-migracao-firebase-auth.md`

Closes #19