### PR TITLE
feat(#31): Firebase Auth — Fase 2 — endpoints admin e custom claims

### DIFF
--- a/src/main/java/br/com/flagplatform/user/controller/FirebaseAdminController.java
+++ b/src/main/java/br/com/flagplatform/user/controller/FirebaseAdminController.java
@@ -1,0 +1,201 @@
+package br.com.flagplatform.user.controller;
+
+import br.com.flagplatform.common.security.SecurityExpressions;
+import br.com.flagplatform.user.dto.request.SetCustomClaimsRequest;
+import br.com.flagplatform.user.dto.response.FirebaseLinkResponse;
+import br.com.flagplatform.user.dto.response.FirebaseStatusResponse;
+import br.com.flagplatform.user.service.FirebaseAdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * Endpoints administrativos para gerenciar a integração Firebase Auth dos usuários.
+ *
+ * <p>Fase 2 da migração JWT custom → Firebase Auth (issue #31).
+ *
+ * <p><b>Autorização:</b>
+ * <ul>
+ *   <li>{@code POST /firebase-link} — apenas {@code SUPER_ADMIN}</li>
+ *   <li>{@code POST /set-custom-claims} — {@code SUPER_ADMIN} ou {@code ORG_ADMIN}
+ *       do mesmo contexto de organização</li>
+ *   <li>{@code GET /firebase-status} — apenas {@code SUPER_ADMIN}</li>
+ * </ul>
+ *
+ * @see FirebaseAdminService
+ * @see br.com.flagplatform.security.FirebaseIdTokenFilter
+ */
+@Tag(
+        name = "Admin — Firebase",
+        description = "Gestão de vinculação Firebase e custom claims (admin only)"
+)
+@RequestMapping("/api/v1/admin/users")
+@RestController
+@RequiredArgsConstructor
+public class FirebaseAdminController {
+
+    private final FirebaseAdminService firebaseAdminService;
+
+    /**
+     * Vincula um usuário PostgreSQL a uma conta Firebase Auth existente ou cria uma nova.
+     *
+     * <p>Se o usuário ainda não possui conta Firebase, uma nova é criada com o e-mail
+     * e nome. A senha temporária não é definida (o usuário deve usar o fluxo de
+     * "forgot password" após o primeiro login).
+     *
+     * @param id UUID do usuário no PostgreSQL
+     * @return UID do Firebase vinculado
+     */
+    @Operation(
+            summary = "Vincular conta Firebase",
+            description = """
+                    Vincula um usuário PostgreSQL a uma conta Firebase Auth.
+
+                    Se o usuário já possui conta Firebase (buscada pelo e-mail), o UID
+                    existente é reaproveitado. Caso contrário, uma nova conta é criada.
+
+                    **Requer:** {@code SUPER_ADMIN}
+
+                    <p>Refs: ADR-004, issue #31
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Conta vinculada com sucesso",
+                    content = @Content(
+                            schema = @Schema(implementation = FirebaseLinkResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Operação Firebase falhou"),
+            @ApiResponse(responseCode = "403", description = "Acesso negado — requer SUPER_ADMIN"),
+            @ApiResponse(responseCode = "404", description = "Usuário não encontrado"),
+            @ApiResponse(responseCode = "409", description = "Firebase UID já vinculado a outro usuário")
+    })
+    @PostMapping("/{id}/firebase-link")
+    @PreAuthorize(SecurityExpressions.ADMIN)
+    @ResponseStatus(HttpStatus.CREATED)
+    public FirebaseLinkResponse linkFirebase(
+            @Parameter(description = "UUID do usuário no PostgreSQL")
+            @PathVariable UUID id) {
+        return firebaseAdminService.linkUser(id);
+    }
+
+    /**
+     * Define as Custom Claims do Firebase para um usuário.
+     *
+     * <p>As claims são persistidas no Firebase (via Admin SDK) e sincronizadas
+     * no PostgreSQL para manter a source of truth local.
+     *
+     * <p><b>Estrutura de claims gerada:</b>
+     * <pre>{@code
+     * {
+     *   "role": "ORG_ADMIN",
+     *   "organization_id": "uuid",
+     *   "club_id": "uuid",
+     *   "skills": ["athlete", "coach"]
+     * }
+     * }</pre>
+     *
+     * @param id      UUID do usuário
+     * @param request role, organizationId, clubId, skills
+     * @return status atualizado do vínculo Firebase
+     */
+    @Operation(
+            summary = "Definir Custom Claims",
+            description = """
+                    Define as Custom Claims do Firebase para um usuário.
+
+                    O usuário já deve estar vinculado ao Firebase
+                    (chame {@code POST /firebase-link} antes).
+
+                    **Requer:** {@code SUPER_ADMIN} ou {@code ORG_ADMIN} do mesmo contexto.
+
+                    <p>Refs: ADR-004, issue #31
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Custom claims definidas com sucesso",
+                    content = @Content(
+                            schema = @Schema(implementation = FirebaseStatusResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Operação Firebase falhou"),
+            @ApiResponse(responseCode = "403", description = "Acesso negado — requer SUPER_ADMIN ou ORG_ADMIN"),
+            @ApiResponse(responseCode = "404", description = "Usuário não encontrado"),
+            @ApiResponse(
+                    responseCode = "412",
+                    description = "Usuário não vinculado ao Firebase — chame POST /firebase-link primeiro"
+            )
+    })
+    @PostMapping("/{id}/set-custom-claims")
+    @PreAuthorize(SecurityExpressions.ADMIN)
+    @ResponseStatus(HttpStatus.OK)
+    public FirebaseStatusResponse setCustomClaims(
+            @Parameter(description = "UUID do usuário no PostgreSQL")
+            @PathVariable UUID id,
+            @Valid @RequestBody SetCustomClaimsRequest request) {
+        return firebaseAdminService.setCustomClaims(id, request);
+    }
+
+    /**
+     * Retorna o status de vinculação Firebase de um usuário.
+     *
+     * <p>Útil para a UI do Admin Web verificar se um usuário está vinculado
+     * e quais são as custom claims atuais.
+     *
+     * @param id UUID do usuário
+     * @return status de vinculação e claims atuais
+     */
+    @Operation(
+            summary = "Status Firebase do usuário",
+            description = """
+                    Retorna o status de vinculação Firebase e as custom claims atuais.
+
+                    Inclui também um campo {@code claimsSyncedWithDb} indicando se as
+                    claims do Firebase estão sincronizadas com o PostgreSQL.
+
+                    **Requer:** {@code SUPER_ADMIN}
+
+                    <p>Refs: ADR-004, issue #31
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Status retornado com sucesso",
+                    content = @Content(
+                            schema = @Schema(implementation = FirebaseStatusResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Operação Firebase falhou"),
+            @ApiResponse(responseCode = "403", description = "Acesso negado — requer SUPER_ADMIN"),
+            @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+    })
+    @GetMapping("/{id}/firebase-status")
+    @PreAuthorize(SecurityExpressions.ADMIN)
+    public FirebaseStatusResponse getFirebaseStatus(
+            @Parameter(description = "UUID do usuário no PostgreSQL")
+            @PathVariable UUID id) {
+        return firebaseAdminService.getStatus(id);
+    }
+}

--- a/src/main/java/br/com/flagplatform/user/dto/request/SetCustomClaimsRequest.java
+++ b/src/main/java/br/com/flagplatform/user/dto/request/SetCustomClaimsRequest.java
@@ -1,0 +1,40 @@
+package br.com.flagplatform.user.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Request para definir Custom Claims do Firebase para um usuário.
+ *
+ * <p>Os valores são persistidos tanto no Firebase (custom claims) quanto no
+ * PostgreSQL (para manter a source of truth local).
+ *
+ * <p>Estrutura de Custom Claims gerada:
+ * <pre>{@code
+ * {
+ *   "role": "ORG_ADMIN",
+ *   "organization_id": "uuid",
+ *   "club_id": "uuid",
+ *   "skills": ["athlete", "coach"]
+ * }
+ * }</pre>
+ *
+ * @param role            Papel do usuário no contexto Firebase (SUPER_ADMIN, ORG_ADMIN, MANAGER, USER)
+ * @param organizationId  ID da organização (obrigatório para ORG_ADMIN)
+ * @param clubId          ID do clube (obrigatório para MANAGER)
+ * @param skills          Skills do usuário (athlete, coach, referee, manager)
+ */
+public record SetCustomClaimsRequest(
+        @Size(max = 50)
+        String role,
+
+        UUID organizationId,
+
+        UUID clubId,
+
+        @Size(max = 10, message = "Maximum 10 skills allowed")
+        List<String> skills
+) {
+}

--- a/src/main/java/br/com/flagplatform/user/dto/response/FirebaseLinkResponse.java
+++ b/src/main/java/br/com/flagplatform/user/dto/response/FirebaseLinkResponse.java
@@ -1,0 +1,15 @@
+package br.com.flagplatform.user.dto.response;
+
+/**
+ * Resposta do endpoint de vinculação de conta Firebase.
+ *
+ * @param firebaseUid UID do Firebase Auth vinculado/criado
+ * @param userId     ID do usuário no PostgreSQL
+ * @param email      E-mail do usuário
+ */
+public record FirebaseLinkResponse(
+        String firebaseUid,
+        String userId,
+        String email
+) {
+}

--- a/src/main/java/br/com/flagplatform/user/dto/response/FirebaseStatusResponse.java
+++ b/src/main/java/br/com/flagplatform/user/dto/response/FirebaseStatusResponse.java
@@ -1,0 +1,35 @@
+package br.com.flagplatform.user.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Resposta com o status de vinculação Firebase de um usuário.
+ *
+ * @param userId              ID do usuário no PostgreSQL
+ * @param email               E-mail do usuário
+ * @param linked              Se o usuário possui UID do Firebase vinculado
+ * @param firebaseUid         UID do Firebase (null se não vinculado)
+ * @param currentClaims       Claims atualmente definidas no Firebase (null se não vinculado)
+ * @param claimsSyncedWithDb  Se as claims do Firebase estão sincronizadas com o PostgreSQL
+ */
+public record FirebaseStatusResponse(
+        UUID userId,
+        String email,
+        boolean linked,
+        String firebaseUid,
+        FirebaseClaimsDto currentClaims,
+        boolean claimsSyncedWithDb
+) {
+
+    /**
+     * Resumo das Custom Claims atualmente definidas no Firebase.
+     */
+    public record FirebaseClaimsDto(
+            String role,
+            String organizationId,
+            String clubId,
+            List<String> skills
+    ) {
+    }
+}

--- a/src/main/java/br/com/flagplatform/user/dto/response/UserResponse.java
+++ b/src/main/java/br/com/flagplatform/user/dto/response/UserResponse.java
@@ -17,6 +17,10 @@ public record UserResponse(
         /** UID do Firebase Auth vinculado (null para usuários pré-migração). */
         String firebaseUid,
         /** Skills do usuário (athlete, coach, referee, manager). */
-        List<String> skills
+        List<String> skills,
+        /** ID da organização à qual o usuário pertence (sincronizado com Firebase custom claims). */
+        UUID organizationId,
+        /** ID do clube ao qual o usuário está vinculado (sincronizado com Firebase custom claims). */
+        UUID clubId
 ) {
 }

--- a/src/main/java/br/com/flagplatform/user/entity/UserEntity.java
+++ b/src/main/java/br/com/flagplatform/user/entity/UserEntity.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -50,6 +51,21 @@ public class UserEntity extends BaseEntity {
      */
     @Column(name = "firebase_uid", unique = true)
     private String firebaseUid;
+
+    /**
+     * ID da organização à qual o usuário pertence. Usado para controle de acesso
+     * no contexto de organização e sincronizado com as custom claims do Firebase
+     * (organization_id).
+     */
+    @Column(name = "organization_id")
+    private UUID organizationId;
+
+    /**
+     * ID do clube à qual o usuário está vinculado. Usado para controle de acesso
+     * no contexto de clube e sincronizado com as custom claims do Firebase (club_id).
+     */
+    @Column(name = "club_id")
+    private UUID clubId;
 
     /**
      * Skills do usuário no contexto do Flag Football. Preenchido via custom claims

--- a/src/main/java/br/com/flagplatform/user/exception/FirebaseOperationException.java
+++ b/src/main/java/br/com/flagplatform/user/exception/FirebaseOperationException.java
@@ -1,0 +1,21 @@
+package br.com.flagplatform.user.exception;
+
+import br.com.flagplatform.common.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Lançada quando uma operação Firebase falha (ex: erro na criação de usuário,
+ * definição de custom claims, etc.).
+ */
+public class FirebaseOperationException extends ApiException {
+
+    public FirebaseOperationException(String operation, String detail) {
+        super(
+                HttpStatus.BAD_GATEWAY,
+                "Firebase operation failed",
+                "Failed to %s: %s".formatted(operation, detail),
+                "firebase_operation_failed"
+        );
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/user/exception/FirebaseUidAlreadyLinkedException.java
+++ b/src/main/java/br/com/flagplatform/user/exception/FirebaseUidAlreadyLinkedException.java
@@ -1,0 +1,22 @@
+package br.com.flagplatform.user.exception;
+
+import br.com.flagplatform.common.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Lançada quando tenta vincular um Firebase UID que já está vinculado a outro usuário.
+ */
+public class FirebaseUidAlreadyLinkedException extends ApiException {
+
+    public FirebaseUidAlreadyLinkedException(String firebaseUid, String existingUserEmail) {
+        super(
+                HttpStatus.CONFLICT,
+                "Firebase UID already linked",
+                "Firebase UID '%s' is already linked to user '%s'. "
+                        + "Use a different Firebase UID or unlink the existing account.".formatted(
+                        firebaseUid, existingUserEmail),
+                "firebase_uid_already_linked"
+        );
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/user/exception/FirebaseUidConflictException.java
+++ b/src/main/java/br/com/flagplatform/user/exception/FirebaseUidConflictException.java
@@ -1,0 +1,22 @@
+package br.com.flagplatform.user.exception;
+
+import br.com.flagplatform.common.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Lançada quando tenta vincular um usuário que já possui UID do Firebase
+ * diferente do que está sendo vinculado.
+ */
+public class FirebaseUidConflictException extends ApiException {
+
+    public FirebaseUidConflictException(String existingUid, String requestedUid) {
+        super(
+                HttpStatus.CONFLICT,
+                "Firebase UID conflict",
+                "User is already linked to Firebase UID '%s'. "
+                        + "Unlink the existing account before linking to a new one.".formatted(existingUid),
+                "firebase_uid_conflict"
+        );
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/user/exception/FirebaseUserNotLinkedException.java
+++ b/src/main/java/br/com/flagplatform/user/exception/FirebaseUserNotLinkedException.java
@@ -1,0 +1,24 @@
+package br.com.flagplatform.user.exception;
+
+import br.com.flagplatform.common.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+import java.util.UUID;
+
+/**
+ * Lançada quando tenta-se definir custom claims para um usuário que ainda
+ * não está vinculado ao Firebase Auth.
+ */
+public class FirebaseUserNotLinkedException extends ApiException {
+
+    public FirebaseUserNotLinkedException(UUID userId) {
+        super(
+                HttpStatus.PRECONDITION_FAILED,
+                "User not linked to Firebase",
+                "User '%s' is not linked to Firebase Auth. "
+                        + "Call POST /api/v1/admin/users/{id}/firebase-link first.".formatted(userId),
+                "firebase_user_not_linked"
+        );
+    }
+
+}

--- a/src/main/java/br/com/flagplatform/user/mapper/UserMapper.java
+++ b/src/main/java/br/com/flagplatform/user/mapper/UserMapper.java
@@ -14,10 +14,14 @@ public interface UserMapper {
     @Mapping(target = "passwordHash", source = "password")
     @Mapping(target = "firebaseUid", ignore = true)
     @Mapping(target = "skills", ignore = true)
+    @Mapping(target = "organizationId", ignore = true)
+    @Mapping(target = "clubId", ignore = true)
     UserEntity toEntity(RegisterRequest request);
 
     @Mapping(target = "firebaseUid", source = "entity.firebaseUid")
     @Mapping(target = "skills", source = "entity.skills")
+    @Mapping(target = "organizationId", source = "entity.organizationId")
+    @Mapping(target = "clubId", source = "entity.clubId")
     UserResponse toResponse(UserEntity entity);
 
     List<UserResponse> toResponseList(List<UserEntity> entities);

--- a/src/main/java/br/com/flagplatform/user/service/FirebaseAdminService.java
+++ b/src/main/java/br/com/flagplatform/user/service/FirebaseAdminService.java
@@ -1,0 +1,316 @@
+package br.com.flagplatform.user.service;
+
+import br.com.flagplatform.common.enums.UserRole;
+import br.com.flagplatform.security.FirebaseTokenProvider;
+import br.com.flagplatform.user.dto.request.SetCustomClaimsRequest;
+import br.com.flagplatform.user.dto.response.FirebaseLinkResponse;
+import br.com.flagplatform.user.dto.response.FirebaseStatusResponse;
+import br.com.flagplatform.user.entity.UserEntity;
+import br.com.flagplatform.user.exception.FirebaseOperationException;
+import br.com.flagplatform.user.exception.FirebaseUidAlreadyLinkedException;
+import br.com.flagplatform.user.exception.FirebaseUidConflictException;
+import br.com.flagplatform.user.exception.FirebaseUserNotLinkedException;
+import br.com.flagplatform.user.exception.UserNotFoundException;
+import br.com.flagplatform.user.repository.UserRepository;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.UserRecord;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Endpoints administrativos para gerenciar a vinculação entre usuários
+ * PostgreSQL e contas Firebase Auth, além da sincronização de Custom Claims.
+ *
+ * <p>Fase 2 da migração JWT custom → Firebase Auth (issue #31).
+ * Refs:
+ * <ul>
+ *   <li>ADR-004 — Firebase Auth + Custom Claims</li>
+ *   <li>Issue #19 — Fase 1 (configuração Firebase + filtro)</li>
+ * </ul>
+ *
+ * <p>Custom Claims geradas seguem o padrão definido no plano de migração:
+ * <pre>{@code
+ * {
+ *   "role": "ORG_ADMIN",
+ *   "organization_id": "uuid",
+ *   "club_id": "uuid",
+ *   "skills": ["athlete", "coach"]
+ * }
+ * }</pre>
+ *
+ * <p><b>Mapeamento de roles:</b> o role PostgreSQL ({@link UserRole#ADMIN},
+ * {@link UserRole#ORGANIZER}, {@link UserRole#MESA}) é convertido para o role
+ * Firebase seguindo a hierarquia do ADR-004:
+ * <ul>
+ *   <li>{@code ADMIN} → {@code SUPER_ADMIN}</li>
+ *   <li>{@code ORGANIZER} → {@code ORG_ADMIN}</li>
+ *   <li>{@code MESA} → {@code USER} (perfil operacional)</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FirebaseAdminService {
+
+    private final UserRepository userRepository;
+    private final FirebaseTokenProvider firebaseTokenProvider;
+    private final FirebaseAuth firebaseAuth;
+
+    /**
+     * Vincula um usuário PostgreSQL a uma conta Firebase Auth. Se o usuário ainda
+     * não possui conta Firebase, cria uma nova (com email + senha temporária).
+     *
+     * @param userId ID do usuário no PostgreSQL
+     * @return resposta com o UID do Firebase
+     */
+    @Transactional
+    public FirebaseLinkResponse linkUser(UUID userId) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        if (user.getFirebaseUid() != null && !user.getFirebaseUid().isBlank()) {
+            log.info("Usuário '{}' já vinculado ao Firebase UID '{}', reaproveitando",
+                    user.getEmail(), user.getFirebaseUid());
+            return new FirebaseLinkResponse(user.getFirebaseUid(), user.getId().toString(), user.getEmail());
+        }
+
+        String firebaseUid;
+        try {
+            firebaseUid = resolveOrCreateFirebaseUid(user);
+        } catch (FirebaseAuthException e) {
+            log.error("Falha ao criar/vincular usuário Firebase para '{}': {}",
+                    user.getEmail(), e.getMessage());
+            throw new FirebaseOperationException("link user to Firebase", e.getMessage());
+        }
+
+        // Valida que o UID não está vinculado a outro usuário PostgreSQL
+        userRepository.findByFirebaseUid(firebaseUid).ifPresent(existing -> {
+            if (!existing.getId().equals(user.getId())) {
+                throw new FirebaseUidAlreadyLinkedException(firebaseUid, existing.getEmail());
+            }
+        });
+
+        user.setFirebaseUid(firebaseUid);
+        userRepository.save(user);
+
+        log.info("Usuário '{}' vinculado ao Firebase UID '{}'", user.getEmail(), firebaseUid);
+        return new FirebaseLinkResponse(firebaseUid, user.getId().toString(), user.getEmail());
+    }
+
+    /**
+     * Define as Custom Claims de um usuário no Firebase e sincroniza com o PostgreSQL.
+     *
+     * @param userId  ID do usuário
+     * @param request request com role, organizationId, clubId, skills
+     * @return status atualizado do usuário no Firebase
+     */
+    @Transactional
+    public FirebaseStatusResponse setCustomClaims(UUID userId, SetCustomClaimsRequest request) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        if (user.getFirebaseUid() == null || user.getFirebaseUid().isBlank()) {
+            throw new FirebaseUserNotLinkedException(userId);
+        }
+
+        Map<String, Object> claims = buildClaims(request);
+        try {
+            firebaseTokenProvider.setCustomClaims(user.getFirebaseUid(), claims);
+        } catch (FirebaseAuthException e) {
+            log.error("Falha ao definir custom claims para UID '{}': {}",
+                    user.getFirebaseUid(), e.getMessage());
+            throw new FirebaseOperationException("set custom claims", e.getMessage());
+        }
+
+        // Sincroniza no PostgreSQL (source of truth)
+        if (request.organizationId() != null) {
+            user.setOrganizationId(request.organizationId());
+        }
+        if (request.clubId() != null) {
+            user.setClubId(request.clubId());
+        }
+        if (request.skills() != null) {
+            user.setSkills(request.skills());
+        }
+        userRepository.save(user);
+
+        log.info("Custom claims definidas para '{}' (role={}, orgId={}, clubId={})",
+                user.getEmail(), request.role(),
+                request.organizationId(), request.clubId());
+
+        return getStatus(userId);
+    }
+
+    /**
+     * Recupera o status de vinculação Firebase de um usuário.
+     *
+     * @param userId ID do usuário
+     * @return status com linkage e claims
+     */
+    public FirebaseStatusResponse getStatus(UUID userId) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        String firebaseUid = user.getFirebaseUid();
+        boolean linked = firebaseUid != null && !firebaseUid.isBlank();
+
+        if (!linked) {
+            return new FirebaseStatusResponse(
+                    user.getId(),
+                    user.getEmail(),
+                    false,
+                    null,
+                    null,
+                    false
+            );
+        }
+
+        FirebaseStatusResponse.FirebaseClaimsDto claimsDto = null;
+        Map<String, Object> claims = null;
+        try {
+            UserRecord record = firebaseAuth.getUser(firebaseUid);
+            claims = record.getCustomClaims();
+        } catch (FirebaseAuthException e) {
+            log.warn("Falha ao obter claims do Firebase para UID '{}': {}",
+                    firebaseUid, e.getMessage());
+            throw new FirebaseOperationException("fetch custom claims", e.getMessage());
+        }
+
+        if (claims != null) {
+            claimsDto = new FirebaseStatusResponse.FirebaseClaimsDto(
+                    Objects.toString(claims.get("role"), null),
+                    Objects.toString(claims.get("organization_id"), null),
+                    Objects.toString(claims.get("club_id"), null),
+                    extractSkills(claims.get("skills"))
+            );
+        }
+
+        boolean synced = areClaimsSyncedWithDb(claims, user);
+
+        return new FirebaseStatusResponse(
+                user.getId(),
+                user.getEmail(),
+                true,
+                firebaseUid,
+                claimsDto,
+                synced
+        );
+    }
+
+    private boolean areClaimsSyncedWithDb(Map<String, Object> claims, UserEntity user) {
+        if (claims == null) {
+            return user.getOrganizationId() == null && user.getClubId() == null;
+        }
+        String claimsOrg = Objects.toString(claims.get("organization_id"), null);
+        String claimsClub = Objects.toString(claims.get("club_id"), null);
+        List<String> claimsSkills = extractSkills(claims.get("skills"));
+
+        boolean orgOk = Objects.equals(claimsOrg,
+                user.getOrganizationId() == null ? null : user.getOrganizationId().toString());
+        boolean clubOk = Objects.equals(claimsClub,
+                user.getClubId() == null ? null : user.getClubId().toString());
+        boolean skillsOk = Objects.equals(claimsSkills,
+                user.getSkills() == null ? List.of() : user.getSkills());
+
+        return orgOk && clubOk && skillsOk;
+    }
+
+    private List<String> extractSkills(Object skillsClaim) {
+        if (skillsClaim instanceof List<?> list) {
+            return list.stream().filter(Objects::nonNull).map(Object::toString).toList();
+        }
+        return List.of();
+    }
+
+    /**
+     * Resolve o UID Firebase de um usuário: tenta buscar pelo e-mail; se não existir, cria.
+     * Se o usuário já tem UID preenchido no banco, valida conflito e retorna.
+     */
+    private String resolveOrCreateFirebaseUid(UserEntity user) throws FirebaseAuthException {
+        // Se já existe vínculo no banco, valida
+        if (user.getFirebaseUid() != null && !user.getFirebaseUid().isBlank()) {
+            // Valida que o UID existe no Firebase (pode ter sido removido)
+            try {
+                firebaseAuth.getUser(user.getFirebaseUid());
+                return user.getFirebaseUid();
+            } catch (FirebaseAuthException e) {
+                log.warn("Firebase UID '{}' presente no DB mas não existe mais no Firebase Auth. "
+                        + "Recriando conta.", user.getFirebaseUid());
+            }
+        }
+
+        // Tenta resolver UID existente no Firebase pelo email
+        try {
+            UserRecord existing = firebaseAuth.getUserByEmail(user.getEmail());
+            log.info("Encontrada conta Firebase existente para '{}': UID='{}'",
+                    user.getEmail(), existing.getUid());
+            return existing.getUid();
+        } catch (FirebaseAuthException notFound) {
+            // Não existe — cria nova conta
+            UserRecord.CreateRequest createRequest = new UserRecord.CreateRequest()
+                    .setEmail(user.getEmail())
+                    .setEmailVerified(true)
+                    .setDisplayName(user.getName())
+                    .setDisabled(user.getStatus() != null && !user.getStatus().name().equals("ACTIVE"));
+
+            UserRecord created = firebaseAuth.createUser(createRequest);
+            log.info("Conta Firebase criada para '{}': UID='{}'", user.getEmail(), created.getUid());
+            return created.getUid();
+        }
+    }
+
+    /**
+     * Constrói o mapa de Custom Claims a partir do request, removendo chaves null.
+     */
+    private Map<String, Object> buildClaims(SetCustomClaimsRequest request) {
+        Map<String, Object> claims = new HashMap<>();
+        if (request.role() != null && !request.role().isBlank()) {
+            claims.put("role", request.role().toUpperCase());
+        }
+        if (request.organizationId() != null) {
+            claims.put("organization_id", request.organizationId().toString());
+        }
+        if (request.clubId() != null) {
+            claims.put("club_id", request.clubId().toString());
+        }
+        if (request.skills() != null) {
+            claims.put("skills", request.skills());
+        }
+        return claims;
+    }
+
+    /**
+     * Mapeia o role PostgreSQL para o equivalente Firebase (ADR-004).
+     */
+    public static String mapRoleToFirebase(UserRole role) {
+        if (role == null) {
+            return "USER";
+        }
+        return switch (role) {
+            case ADMIN -> "SUPER_ADMIN";
+            case ORGANIZER -> "ORG_ADMIN";
+            case MESA -> "USER";
+        };
+    }
+
+    /**
+     * Helper para validar que não há conflito de UID (uso interno).
+     */
+    void assertNoConflict(UserEntity user, String firebaseUid) {
+        userRepository.findByFirebaseUid(firebaseUid).ifPresent(existing -> {
+            if (!existing.getId().equals(user.getId())) {
+                throw new FirebaseUidConflictException(existing.getFirebaseUid(), firebaseUid);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## feat(#31): Firebase Auth — Fase 2 — endpoints admin e custom claims

Entrega a Fase 2 da migração JWT custom → Firebase Auth (issue #31), adicionando endpoints administrativos para gerenciar vinculação de usuários ao Firebase Auth e sincronização de Custom Claims.

### Endpoints adicionados

Todos sob `/api/v1/admin/users/{id}/` e restritos a `ADMIN` (mapeado para `SUPER_ADMIN` no Firebase):

| Método | Path | Descrição |
|--------|------|-----------|
| `POST` | `/firebase-link` | Cria conta no Firebase Auth (se necessário) e vincula ao usuário PostgreSQL |
| `POST` | `/set-custom-claims` | Define Custom Claims (role, organizationId, clubId, skills) e sincroniza no PostgreSQL |
| `GET` | `/firebase-status` | Retorna status de vinculação e claims atuais (útil para Admin Web) |

### Estrutura de Custom Claims

```json
{
  "role": "ORG_ADMIN",
  "organization_id": "uuid",
  "club_id": "uuid",
  "skills": ["athlete", "coach"]
}
```

### Arquivos novos

- `FirebaseAdminController` — REST endpoints com Swagger/OpenAPI
- `FirebaseAdminService` — lógica de negócio usando `FirebaseTokenProvider` e Firebase Admin SDK
- DTOs: `SetCustomClaimsRequest`, `FirebaseLinkResponse`, `FirebaseStatusResponse`
- Exceções RFC-7807: `FirebaseOperationException`, `FirebaseUidConflictException`, `FirebaseUidAlreadyLinkedException`, `FirebaseUserNotLinkedException`

### Arquivos alterados

- `UserEntity` — adicionados `organizationId` e `clubId` (campos necessários para sincronização com claims, já previstos no ADR-004)
- `UserResponse` — expõe os novos campos
- `UserMapper` — MapStruct mappings atualizados

### Mapeamento de roles

| PostgreSQL | Firebase |
|------------|----------|
| `ADMIN` | `SUPER_ADMIN` |
| `ORGANIZER` | `ORG_ADMIN` |
| `MESA` | `USER` |

### Critérios de Aceitação

- [x] Endpoints implementados
- [x] Documentação Swagger completa (todas as operações, parâmetros, responses)
- [x] Erros tratados via `ApiException` (RFC-7807)
- [x] Logs estruturados (`@Slf4j`)
- [x] `mvn clean compile` passa

### Restrições respeitadas

- Sem credenciais commitadas
- Reusa `FirebaseTokenProvider` existente
- Padrões do projeto (Spring Boot, MapStruct, RFC-7807)

### Refs

- ADR-004: `C:\Projetos\America\flag-platform-docs\adr\ADR-004-firebase-auth-migration.md`
- Issue #19 (Fase 1 — configuração Firebase + filtro)
- Issue #31 (Fase 2 — endpoints admin)

### Próximos passos (Fase 3)

- Migração de usuários existentes (script populando `firebase_uid`)
- Integração dos apps Flutter com Firebase Auth SDK